### PR TITLE
Recording OAB importer errors

### DIFF
--- a/app/importers/open_access_button_publication_importer.rb
+++ b/app/importers/open_access_button_publication_importer.rb
@@ -58,6 +58,7 @@ class OpenAccessButtonPublicationImporter
   rescue StandardError => e
     ImporterErrorLog::OpenAccessButtonImporterErrorLog.create!(
                                              error_type: e.class.to_s,
+                                             error_message: e.message.to_s,
                                              metadata: {
                                                publication_id: publication&.id,
                                                publication_doi_url_path: publication&.doi_url_path,

--- a/db/migrate/20211006183554_add_error_message_to_import_error_logs.rb
+++ b/db/migrate/20211006183554_add_error_message_to_import_error_logs.rb
@@ -1,0 +1,5 @@
+class AddErrorMessageToImportErrorLogs < ActiveRecord::Migration[5.2]
+  def change
+    add_column :importer_error_logs, :error_message, :text, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_06_155521) do
+ActiveRecord::Schema.define(version: 2021_10_06_183554) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -203,6 +203,7 @@ ActiveRecord::Schema.define(version: 2021_10_06_155521) do
     t.jsonb "metadata"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "error_message", null: false
     t.index ["importer_type"], name: "index_importer_error_logs_on_importer_type"
   end
 

--- a/spec/component/importers/open_access_button_publication_importer_spec.rb
+++ b/spec/component/importers/open_access_button_publication_importer_spec.rb
@@ -261,6 +261,7 @@ describe OpenAccessButtonPublicationImporter do
 
         log = ImporterErrorLog::OpenAccessButtonImporterErrorLog.last
         expect(log.error_type).to eq 'RuntimeError'
+        expect(log.error_message).to be_present
         expect(log.metadata["publication_id"]).to eq pub.id
         expect(log.metadata["publication_doi_url_path"]).to eq pub.doi_url_path
         expect(log.metadata["oab_json"]).to eq ''

--- a/spec/component/models/importer_error_log_spec.rb
+++ b/spec/component/models/importer_error_log_spec.rb
@@ -8,6 +8,7 @@ describe 'the import_error_logs table', type: :model do
   it { is_expected.to have_db_column(:id).of_type(:integer).with_options(null: false) }
   it { is_expected.to have_db_column(:importer_type).of_type(:string).with_options(null: false) }
   it { is_expected.to have_db_column(:error_type).of_type(:string).with_options(null: false) }
+  it { is_expected.to have_db_column(:error_message).of_type(:text).with_options(null: false) }
   it { is_expected.to have_db_column(:stacktrace).of_type(:text).with_options(null: false) }
   it { is_expected.to have_db_column(:metadata).of_type(:jsonb) }
   it { is_expected.to have_db_column(:occurred_at).of_type(:datetime).with_options(null: false) }


### PR DESCRIPTION
Closes #187

Recording OAB Importer errors using a respective subclass to ImporterErrorLog based on #230, also added error_message column to the existing table.

