### PR TITLE
Psu identity importer

### DIFF
--- a/app/importers/psu_identity_importer.rb
+++ b/app/importers/psu_identity_importer.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class PsuIdentityImporter
+  DEFAULT_WAIT_TIME = 0.1
+
+  def call
+    User.find_each do |user|
+      user.update_psu_identity
+      progress_bar.increment
+      sleep DEFAULT_WAIT_TIME
+    rescue StandardError => e
+      log_error(e, user)
+    end
+    progress_bar.finish
+  rescue StandardError => e
+    log_error(e)
+  end
+
+  private
+
+    def progress_bar
+      @progress_bar ||= ProgressBar.create(title: 'Importing data from Penn State Identity API', total: User.count)
+    end
+
+    def log_error(error, user = nil)
+      ImporterErrorLog.log_error(
+        importer_class: self.class,
+        error: error,
+        metadata: { user_id: user&.id }
+      )
+    end
+end

--- a/lib/tasks/imports.rake
+++ b/lib/tasks/imports.rake
@@ -85,6 +85,11 @@ namespace :import do
     LDAPImporter.new.call
   end
 
+  desc 'Import PSU identity data'
+  task psu_identity: :environment do
+    PsuIdentityImporter.new.call
+  end
+
   desc 'Import publication data from Penn State Law School OAI repositories'
   task law_school_publications: :environment do
     PSULawSchoolPublicationImporter.new.call

--- a/spec/component/importers/psu_identity_importer_spec.rb
+++ b/spec/component/importers/psu_identity_importer_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'component/component_spec_helper'
+
+describe PsuIdentityImporter do
+  let(:importer) { described_class.new }
+  let(:mock_client) { instance_spy(PsuIdentity::SearchService::Client) }
+
+  let!(:user_1) { create :user, webaccess_id: 'abc1' }
+  let!(:user_2) { create :user, webaccess_id: 'def2' }
+  let!(:user_3) { create :user, webaccess_id: 'ghi3' }
+
+  before do
+    allow(PsuIdentity::SearchService::Client).to receive(:new).and_return(mock_client)
+  end
+
+  describe '#call' do
+    context 'when there are no errors' do
+      it "updates each user's ORCID ID with the value returned from LDAP" do
+        importer.call
+
+        expect(mock_client).to have_received(:userid).with(user_1.webaccess_id)
+        expect(mock_client).to have_received(:userid).with(user_2.webaccess_id)
+        expect(mock_client).to have_received(:userid).with(user_3.webaccess_id)
+      end
+    end
+
+    context 'when a user fails to update' do
+      before do
+        allow(mock_client).to receive(:userid).and_raise(RuntimeError)
+        allow(ImporterErrorLog).to receive(:log_error)
+      end
+
+      it 'captures the error' do
+        importer.call
+
+        expect(ImporterErrorLog).to have_received(:log_error).with(
+          importer_class: described_class,
+          error: instance_of(RuntimeError),
+          metadata: {
+            user_id: user_1.id
+          }
+        )
+      end
+    end
+
+    context 'when the import fails' do
+      before do
+        allow(User).to receive(:find_each).and_raise(RuntimeError)
+        allow(ImporterErrorLog).to receive(:log_error)
+      end
+
+      it 'logs the error' do
+        importer.call
+
+        expect(ImporterErrorLog).to have_received(:log_error).with(
+          importer_class: described_class,
+          error: instance_of(RuntimeError),
+          metadata: {
+            user_id: nil
+          }
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds a new importer class for importing and updating data from Penn State's identity API. All users are updated and any errors are logged to the database.

Fixes #286 