### PR TITLE
Add 'Active' tab to admin user display

### DIFF
--- a/app/models/admin/users.rb
+++ b/app/models/admin/users.rb
@@ -12,6 +12,7 @@ module Admin::Users
       end
 
       list do
+        scopes [nil, :active]
         field(:id) do
           visible do
             bindings[:view]._current_user.is_admin

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,6 +41,8 @@ class User < ApplicationRecord
   has_many :external_publication_waivers
   has_many :contributor_names
 
+  scope :active, -> { where.not(psu_identity: nil).where("psu_identity->'data'->>'affiliation' != '[\"MEMBER\"]'") }
+
   accepts_nested_attributes_for :user_organization_memberships, allow_destroy: true
 
   def self.from_omniauth(auth)

--- a/spec/component/models/user_spec.rb
+++ b/spec/component/models/user_spec.rb
@@ -104,6 +104,16 @@ describe User, type: :model do
     end
   end
 
+  describe 'active scope' do
+    let!(:active_user) { create(:user, :with_psu_identity) }
+    let!(:member_user) { create(:user, :with_psu_member_affiliation) }
+    let!(:inactve_user) { create(:user, :with_inactive_psu_identity) }
+
+    it 'limits to active users' do
+      expect(described_class.active.map(&:webaccess_id)).to contain_exactly(active_user.webaccess_id)
+    end
+  end
+
   it { is_expected.to accept_nested_attributes_for(:user_organization_memberships).allow_destroy(true) }
 
   describe 'saving a value for webaccess_id' do

--- a/spec/integration/admin/users/index_spec.rb
+++ b/spec/integration/admin/users/index_spec.rb
@@ -17,6 +17,10 @@ describe 'Admin user list', type: :feature do
         expect(page).to have_content 'List of Users'
       end
 
+      it 'has a tab for "Active" users' do
+        expect(page).to have_link('Active', href: '/admin/user?model_name=user&scope=active')
+      end
+
       it 'shows information about each user' do
         expect(page).to have_content user1.id
         expect(page).to have_content 'Bob'


### PR DESCRIPTION
Uses an ActiveRecord scope to limit results to only active users in the admin display panel.

![Screen Shot 2021-10-19 at 4 16 44 PM](https://user-images.githubusercontent.com/312085/137983947-3218228b-40a9-4dd3-ae85-e38121562c53.png)
