### PR TITLE
Allow admins to create OA locations with source “scholarsphere”

### DIFF
--- a/app/models/open_access_location.rb
+++ b/app/models/open_access_location.rb
@@ -47,7 +47,11 @@ class OpenAccessLocation < ApplicationRecord
       field(:url) { label 'URL' }
       field(:source, :enum) do
         enum do
-          [value || Source::USER].index_by { |str| Source.new(str).display }
+          if value
+            [value].index_by { |str| Source.new(str).display }
+          else
+            [Source::USER, Source::SCHOLARSPHERE].index_by { |str| Source.new(str).display }
+          end
         end
       end
     end
@@ -56,7 +60,11 @@ class OpenAccessLocation < ApplicationRecord
       field(:url) { label 'URL' }
       field(:source, :enum) do
         enum do
-          [value || Source::USER].index_by { |str| Source.new(str).display }
+          if value
+            [value].index_by { |str| Source.new(str).display }
+          else
+            [Source::USER, Source::SCHOLARSPHERE].index_by { |str| Source.new(str).display }
+          end
         end
       end
     end

--- a/spec/integration/admin/open_access_locations/create_spec.rb
+++ b/spec/integration/admin/open_access_locations/create_spec.rb
@@ -34,7 +34,9 @@ describe 'Creating an open access location', type: :feature do
       it 'shows the correct options for the Source field', js: true do
         find('.dropdown-toggle').click
         within '#ui-id-1' do
-          expect(page).to have_content 'User'
+          expect(page).to have_content Source.new(Source::USER).display
+          expect(page).to have_content Source.new(Source::SCHOLARSPHERE).display
+          expect(page).not_to have_content Source.new(Source::OPEN_ACCESS_BUTTON).display
         end
       end
     end


### PR DESCRIPTION
This allows admins to create new open access locations that have a source of either "User" or "ScholarSphere". It still prohibits changing the source on an existing open access location. If necessary, we could remove that restriction too, but I'd rather only do that if we have a use case for it.