### PR TITLE
Import faculty titles form AI and display

### DIFF
--- a/app/importers/activity_insight_importer.rb
+++ b/app/importers/activity_insight_importer.rb
@@ -335,7 +335,7 @@ class ActivityInsightDetailUser
   end
 
   def ai_title
-    user.css('ADMIN').first.css('RANK').text.strip.presence
+    user.css('ADMIN')&.first&.css('RANK')&.text&.strip.presence
   end
 
   def webaccess_id

--- a/app/importers/activity_insight_importer.rb
+++ b/app/importers/activity_insight_importer.rb
@@ -26,6 +26,7 @@ class ActivityInsightImporter
           u.penn_state_identifier = aiu.penn_state_id
           u.activity_insight_identifier = aiu.activity_insight_id
 
+          u.ai_title = details.ai_title
           u.ai_building = details.building
           u.ai_alt_name = details.alt_name
           u.ai_room_number = details.room_number
@@ -331,6 +332,10 @@ end
 class ActivityInsightDetailUser
   def initialize(parsed_user)
     @parsed_user = parsed_user
+  end
+
+  def ai_title
+    user.css('ADMIN').first.css('RANK').text.strip.presence
   end
 
   def webaccess_id

--- a/app/models/admin/users.rb
+++ b/app/models/admin/users.rb
@@ -91,8 +91,6 @@ module Admin::Users
         field(:psu_identity_updated_at) { label 'Identity Updated On' }
         field(:scopus_h_index) { label 'H-Index' }
         field(:ai_title) { label 'Title' }
-        field(:ai_rank) { label 'Rank' }
-        field(:ai_endowed_title) { label 'Endowed Title' }
         field(:orcid_identifier) do
           label 'ORCID ID'
           pretty_value { %{<a href="#{value}" target="_blank">#{value}</a>}.html_safe if value }

--- a/app/models/user_profile.rb
+++ b/app/models/user_profile.rb
@@ -20,7 +20,9 @@ class UserProfile
            to: :user
 
   def title
-    user.ai_title
+    user.ai_title ||
+      user.user_organization_memberships.where(primary: true).first&.position_title ||
+      user.user_organization_memberships.order('started_on').last&.position_title
   end
 
   def email

--- a/db/migrate/20220817195021_remove_ai_rank_and_ai_endowed_title_from_users.rb
+++ b/db/migrate/20220817195021_remove_ai_rank_and_ai_endowed_title_from_users.rb
@@ -1,0 +1,11 @@
+class RemoveAiRankAndAiEndowedTitleFromUsers < ActiveRecord::Migration[6.1]
+  def up
+    remove_column :users, :ai_rank, :string
+    remove_column :users, :ai_endowed_title, :string
+  end
+
+  def down
+    add_column :users, :ai_rank, :string
+    add_column :users, :ai_endowed_title, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_17_144654) do
+ActiveRecord::Schema.define(version: 2022_08_17_195021) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -599,8 +599,6 @@ ActiveRecord::Schema.define(version: 2021_11_17_144654) do
     t.boolean "show_all_contracts", default: false
     t.integer "scopus_h_index"
     t.string "ai_title"
-    t.string "ai_rank"
-    t.string "ai_endowed_title"
     t.string "orcid_identifier"
     t.string "ai_alt_name"
     t.string "ai_building"

--- a/spec/component/importers/activity_insight_importer_spec.rb
+++ b/spec/component/importers/activity_insight_importer_spec.rb
@@ -40,6 +40,7 @@ describe ActivityInsightImporter do
         expect(u1.last_name).to eq 'Testuser'
         expect(u1.activity_insight_identifier).to eq '1649499'
         expect(u1.penn_state_identifier).to eq '976567444'
+        expect(u1.ai_title).to eq 'Associate Professor'
         expect(u1.ai_building).to eq "Sally's Building"
         expect(u1.ai_room_number).to eq '123'
         expect(u1.ai_office_area_code).to eq '444'
@@ -1619,6 +1620,7 @@ describe ActivityInsightImporter do
           expect(u1.last_name).to eq 'User'
           expect(u1.activity_insight_identifier).to eq '1649499'
           expect(u1.penn_state_identifier).to eq '999999999'
+          expect(u1.ai_title).to be_nil
           expect(u1.ai_building).to be_nil
           expect(u1.ai_room_number).to be_nil
           expect(u1.ai_office_area_code).to be_nil
@@ -3202,6 +3204,7 @@ describe ActivityInsightImporter do
           expect(u1.last_name).to eq 'Testuser'
           expect(u1.activity_insight_identifier).to eq '1649499'
           expect(u1.penn_state_identifier).to eq '976567444'
+          expect(u1.ai_title).to eq 'Associate Professor'
           expect(u1.ai_building).to eq "Sally's Building"
           expect(u1.ai_room_number).to eq '123'
           expect(u1.ai_office_area_code).to eq '444'

--- a/spec/component/models/user_spec.rb
+++ b/spec/component/models/user_spec.rb
@@ -23,8 +23,6 @@ describe 'the users table', type: :model do
   it { is_expected.to have_db_column(:updated_at).of_type(:datetime).with_options(null: false) }
   it { is_expected.to have_db_column(:updated_by_user_at).of_type(:datetime) }
   it { is_expected.to have_db_column(:ai_title).of_type(:string) }
-  it { is_expected.to have_db_column(:ai_rank).of_type(:string) }
-  it { is_expected.to have_db_column(:ai_endowed_title).of_type(:string) }
   it { is_expected.to have_db_column(:orcid_identifier).of_type(:string) }
   it { is_expected.to have_db_column(:ai_alt_name).of_type(:string) }
   it { is_expected.to have_db_column(:ai_building).of_type(:string) }

--- a/spec/fixtures/activity_insight_user_abc123.xml
+++ b/spec/fixtures/activity_insight_user_abc123.xml
@@ -40,6 +40,88 @@
       <UPLOAD_PHOTO/>
       <UPLOAD_CV>abc123/pci/test-cv-5.pdf</UPLOAD_CV>
     </PCI>
+    <ADMIN id="222201395200" dmd:originalSource="MANUAL" dmd:created="2021-07-01T08:23:40" dmd:lastModifiedSource="MANUAL" dmd:lastModified="2022-08-17T12:14:35" dmd:startDate="2021-07-01" dmd:endDate="2022-06-30" dmd:primaryKey="2021-2022">
+			<AC_YEAR>2021-2022</AC_YEAR>
+			<YEAR_START>2021-07-01</YEAR_START>
+			<YEAR_END>2022-06-30</YEAR_END>
+			<CAMPUS/>
+			<CAMPUS_NAME>University Park</CAMPUS_NAME>
+			<COLLEGE>UL</COLLEGE>
+			<COLLEGE_NAME/>
+			<SCHOOL/>
+			<DIVISION/>
+			<INSTITUTE/>
+			<ADMIN_DEP id="222201395205">
+				<DEP/>
+				<DEP_OTHER/>
+				<LIBRARY/>
+			</ADMIN_DEP>
+			<TITLE>Associate Professor</TITLE>
+			<RANK>Associate Professor</RANK>
+			<TENURE></TENURE>
+			<ENDPOS/>
+			<GRADUATE></GRADUATE>
+			<LEAVE/>
+			<LEAVE_OTHER/>
+			<DTM_START/>
+			<DTD_START/>
+			<DTY_START/>
+			<START_START></START_START>
+			<START_END></START_END>
+			<DTM_END/>
+			<DTD_END/>
+			<DTY_END/>
+			<END_START></END_START>
+			<END_END></END_END>
+			<RESULT_SABB/>
+			<TIME_STATUS>Full Time</TIME_STATUS>
+			<HR_CODE>ACT</HR_CODE>
+			<MD_EMPLOYER>Penn State University</MD_EMPLOYER>
+			<FTE/>
+			<FTE_EXTERN/>
+			<DEDMISS/>
+		</ADMIN>
+    <ADMIN id="222201395200" dmd:originalSource="MANUAL" dmd:created="2021-07-01T08:23:40" dmd:lastModifiedSource="MANUAL" dmd:lastModified="2022-08-17T12:14:35" dmd:startDate="2021-07-01" dmd:endDate="2022-06-30" dmd:primaryKey="2021-2022">
+			<AC_YEAR>2020-2021</AC_YEAR>
+			<YEAR_START>2020-07-01</YEAR_START>
+			<YEAR_END>2021-06-30</YEAR_END>
+			<CAMPUS/>
+			<CAMPUS_NAME>University Park</CAMPUS_NAME>
+			<COLLEGE>UL</COLLEGE>
+			<COLLEGE_NAME/>
+			<SCHOOL/>
+			<DIVISION/>
+			<INSTITUTE/>
+			<ADMIN_DEP id="222201395206">
+				<DEP/>
+				<DEP_OTHER/>
+				<LIBRARY/>
+			</ADMIN_DEP>
+			<TITLE>Lecturer</TITLE>
+			<RANK>Lecturer</RANK>
+			<TENURE></TENURE>
+			<ENDPOS/>
+			<GRADUATE></GRADUATE>
+			<LEAVE/>
+			<LEAVE_OTHER/>
+			<DTM_START/>
+			<DTD_START/>
+			<DTY_START/>
+			<START_START></START_START>
+			<START_END></START_END>
+			<DTM_END/>
+			<DTD_END/>
+			<DTY_END/>
+			<END_START></END_START>
+			<END_END></END_END>
+			<RESULT_SABB/>
+			<TIME_STATUS>Full Time</TIME_STATUS>
+			<HR_CODE>ACT</HR_CODE>
+			<MD_EMPLOYER>Penn State University</MD_EMPLOYER>
+			<FTE/>
+			<FTE_EXTERN/>
+			<DEDMISS/>
+		</ADMIN>
     <EDUCATION id="70766815232" dmd:originalSource="MANUAL" dmd:created="2013-04-12T10:00:41" dmd:lastModifiedSource="MANUAL" dmd:lastModified="2013-04-12T10:00:41" dmd:startDate="2006-09-27" dmd:endDate="2009-12-18">
       <DEG>Ph D</DEG>
       <DEGOTHER/>

--- a/spec/integration/admin/users/show_spec.rb
+++ b/spec/integration/admin/users/show_spec.rb
@@ -127,14 +127,6 @@ describe 'Admin user detail page', type: :feature do
         expect(page).to have_content 'Test Title'
       end
 
-      it "shows the user's rank" do
-        expect(page).to have_content 'Test Rank'
-      end
-
-      it "shows the user's endowed title" do
-        expect(page).to have_content 'Test Endowed Title'
-      end
-
       it "shows the user's Orcid ID" do
         expect(page).to have_link 'Test Orcid ID', href: 'Test Orcid ID'
       end

--- a/spec/integration/admin/users/show_spec.rb
+++ b/spec/integration/admin/users/show_spec.rb
@@ -13,7 +13,6 @@ describe 'Admin user detail page', type: :feature do
                        penn_state_identifier: 'psu345678',
                        scopus_h_index: 724,
                        ai_title: 'Test Title',
-                       ai_rank: 'Test Rank', ai_endowed_title: 'Test Endowed Title',
                        orcid_identifier: 'Test Orcid ID',
                        ai_alt_name: 'Test Alt Name',
                        ai_building: 'Test Building',


### PR DESCRIPTION
We are now importing faculty titles from Activity Insight... again.  I removed the `ai_rank` and `ai_endowed_title` attributes for `User` that we used to import way back when.  They are no longer being used.  All we need now is `ai_title`. 

When displaying titles, `ai_title` is given preference.  If that is not present, the Organization `position_title` that is flagged as `primary` is given preference.  If that does not exist, the Organization `position_title` with the most recent `started_on` date is chosen.