### PR TITLE
Temporary tasks to get lost scholarsphere oals

### DIFF
--- a/lib/tasks/database_data.rake
+++ b/lib/tasks/database_data.rake
@@ -57,7 +57,7 @@ namespace :database_data do
     filename = File.basename(Dir["#{Rails.root}/tmp/psql-rmd-prod-data-*.sql.gz"].first, '.gz')
 
     # Get local db config
-    db_config = YAML.load_file("#{Rails.root}/config/database.yml")
+    db_config = YAML.safe_load(File.open("#{Rails.root}/config/database.yml"), aliases: true)
 
     # Unzip production data file
     `gunzip #{Rails.root}/tmp/#{filename}.gz`

--- a/lib/tasks/scholarsphere_oals_json.rake
+++ b/lib/tasks/scholarsphere_oals_json.rake
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+desc 'Import Scholarsphere OALs from JSON
+      Used for getting lost OALs from RMD backups'
+
+task no_doi_scholarsphere_oals_to_json: :environment do
+  File.write("#{Rails.root}/tmp/scholarsphere_oals.json", ScholarsphereWorkDeposit.where(doi: '').map { |s| s.publication.open_access_locations.where(source: 'scholarsphere') }.flatten.uniq.to_json)
+end
+
+task import_scholarsphere_oals_json: :environment do
+  file = File.read("#{Rails.root}/tmp/scholarsphere_oals.json")
+  json = JSON.parse(file)
+  json.each do |oal|
+    OpenAccessLocation.create(oal.except('source').merge('source' => 'scholarsphere'))
+  end
+end

--- a/lib/tasks/scholarsphere_oals_json.rake
+++ b/lib/tasks/scholarsphere_oals_json.rake
@@ -12,5 +12,7 @@ task import_scholarsphere_oals_json: :environment do
   json = JSON.parse(file)
   json.each do |oal|
     OpenAccessLocation.create(oal.except('source').merge('source' => 'scholarsphere'))
+  rescue ActiveRecord::RecordNotUnique
+    next
   end
 end


### PR DESCRIPTION
@banukutlu I'm just going to deploy this branch temporarily to production (after I test it on qa), run the task, and then redeploy the last release once its done.  Then, I'll just delete this branch since it is only meant to be temporary.

@anaelizabethenriquez There were only 81 Scholarsphere Open Access Locations with an associated Scholarsphere Work Deposit that had no DOI.  I was only able to identify 2 of the three Scholarsphere Work Deposits with no DOI and an associated publication that has no Scholarsphere OAL.  The Scholarsphere Work Deposit IDs for these two are 1138 and 42.  Not sure what the issue is with these.  I'm also not sure why the third one isn't popping up in my queries.  I must be forgetting something 🤔 .

Edit: The third one has a Scholarsphere Work Deposit ID of 201.  It wasn't showing up in my queries because this publication doesn't have any OALs.