### PR TITLE
463 email conf

### DIFF
--- a/app/models/oa_notification_setting.rb
+++ b/app/models/oa_notification_setting.rb
@@ -1,0 +1,28 @@
+class OaNotificationSetting < ApplicationRecord
+  # There should only be one OaNotificationSetting record
+  validate :one_record_validation
+
+  def self.email_cap
+    first.email_cap
+  end
+
+  def self.is_active
+    first.is_active
+  end
+
+  def self.is_not_active
+    !first.is_active
+  end
+
+  def self.seed
+    return if count > 0
+
+    create email_cap: 300, is_active: true
+  end
+
+  private
+
+    def one_record_validation
+      errors.add(:a_record_exists, ', there can only be one OaNotificationSetting record') if self.class.count > 0
+    end
+end

--- a/app/models/oa_notification_setting.rb
+++ b/app/models/oa_notification_setting.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class OaNotificationSetting < ApplicationRecord
   # The "singleton_guard" column is a unique column which must always be set to '0'
   # This ensures that only one OaNotificationSettings row is created
@@ -8,7 +10,7 @@ class OaNotificationSetting < ApplicationRecord
       instance.email_cap
     end
 
-    def is_not_active
+    def not_active?
       !instance.is_active
     end
 

--- a/app/models/oa_notification_setting.rb
+++ b/app/models/oa_notification_setting.rb
@@ -1,28 +1,33 @@
 class OaNotificationSetting < ApplicationRecord
-  # There should only be one OaNotificationSetting record
-  validate :one_record_validation
+  # The "singleton_guard" column is a unique column which must always be set to '0'
+  # This ensures that only one OaNotificationSettings row is created
+  validates :singleton_guard, inclusion: { in: [0] }
 
-  def self.email_cap
-    first.email_cap
-  end
-
-  def self.is_active
-    first.is_active
-  end
-
-  def self.is_not_active
-    !first.is_active
-  end
-
-  def self.seed
-    return if count > 0
-
-    create email_cap: 300, is_active: true
-  end
-
-  private
-
-    def one_record_validation
-      errors.add(:a_record_exists, ', there can only be one OaNotificationSetting record') if self.class.count > 0
+  class << self
+    def email_cap
+      instance.email_cap
     end
+
+    def is_not_active
+      !instance.is_active
+    end
+
+    def instance
+      first_or_create!(singleton_guard: 0, email_cap: 100, is_active: true)
+    end
+  end
+
+  rails_admin do
+    edit do
+      field(:singleton_guard) { visible false }
+      field(:email_cap)
+      field(:is_active)
+    end
+
+    show do
+      field(:singleton_guard) { visible false }
+      field(:email_cap)
+      field(:is_active)
+    end
+  end
 end

--- a/app/models/oa_notification_setting.rb
+++ b/app/models/oa_notification_setting.rb
@@ -21,13 +21,16 @@ class OaNotificationSetting < ApplicationRecord
 
   rails_admin do
     edit do
-      field(:singleton_guard) { visible false }
       field(:email_cap)
       field(:is_active)
     end
 
     show do
-      field(:singleton_guard) { visible false }
+      field(:email_cap)
+      field(:is_active)
+    end
+
+    list do
       field(:email_cap)
       field(:is_active)
     end

--- a/app/models/open_access_notifier.rb
+++ b/app/models/open_access_notifier.rb
@@ -11,8 +11,8 @@ class OpenAccessNotifier
     end
   end
 
-  def send_first_five_notifications
-    first_five_users.each do |u|
+  def send_notifications_with_cap(cap)
+    users.first(cap).each do |u|
       send_notification_to_user(u)
     end
   end
@@ -21,10 +21,6 @@ class OpenAccessNotifier
 
     def users
       @users.needs_open_access_notification
-    end
-
-    def first_five_users
-      users.first(5)
     end
 
     def send_notification_to_user(user)

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -64,7 +64,8 @@ RailsAdmin.config do |config|
             :EmailError,
             :ScholarsphereWorkDeposit,
             :ImporterErrorLog,
-            :Authorship]
+            :Authorship,
+            :OaNotificationSetting]
     end
     new do
       only [:Authorship,
@@ -90,7 +91,8 @@ RailsAdmin.config do |config|
             :APIToken,
             :ExternalPublicationWaiver,
             :InternalPublicationWaiver,
-            :OpenAccessLocation]
+            :OpenAccessLocation,
+            :OaNotificationSetting]
     end
     delete do
       only [:APIToken,

--- a/db/migrate/20220831151648_create_oa_notification_settings.rb
+++ b/db/migrate/20220831151648_create_oa_notification_settings.rb
@@ -1,0 +1,10 @@
+class CreateOaNotificationSettings < ActiveRecord::Migration[6.1]
+  def change
+    create_table :oa_notification_settings do |t|
+      t.integer :email_cap
+      t.boolean :is_active
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220831151648_create_oa_notification_settings.rb
+++ b/db/migrate/20220831151648_create_oa_notification_settings.rb
@@ -1,10 +1,13 @@
 class CreateOaNotificationSettings < ActiveRecord::Migration[6.1]
   def change
     create_table :oa_notification_settings do |t|
+      t.integer   :singleton_guard
       t.integer :email_cap
       t.boolean :is_active
 
       t.timestamps
     end
+
+    add_index(:oa_notification_settings, :singleton_guard, :unique => true)
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -298,10 +298,12 @@ ActiveRecord::Schema.define(version: 2022_08_31_151648) do
   end
 
   create_table "oa_notification_settings", force: :cascade do |t|
+    t.integer "singleton_guard"
     t.integer "email_cap"
     t.boolean "is_active"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["singleton_guard"], name: "index_oa_notification_settings_on_singleton_guard", unique: true
   end
 
   create_table "open_access_locations", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_17_195021) do
+ActiveRecord::Schema.define(version: 2022_08_31_151648) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -295,6 +295,13 @@ ActiveRecord::Schema.define(version: 2022_08_17_195021) do
   create_table "non_duplicate_publication_groups", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "oa_notification_settings", force: :cascade do |t|
+    t.integer "email_cap"
+    t.boolean "is_active"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "open_access_locations", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,5 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+OaNotificationSetting.seed

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,4 +6,4 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-OaNotificationSetting.seed
+OaNotificationSetting.instance

--- a/lib/tasks/database_data.rake
+++ b/lib/tasks/database_data.rake
@@ -17,7 +17,7 @@ namespace :database_data do
 
     Net::SSH.start(hostname, 'deploy', port: 1855) do |ssh|
       # Pull down db config to be parsed
-      db_config = YAML.safe_load(ssh.exec!('cat rmd/current/config/database.yml'))
+      db_config = YAML.safe_load(ssh.exec!('cat rmd/current/config/database.yml'), aliases: true)
 
       # Parse values from db config
       db_password = db_config['production']['password']
@@ -57,7 +57,7 @@ namespace :database_data do
     filename = File.basename(Dir["#{Rails.root}/tmp/psql-rmd-prod-data-*.sql.gz"].first, '.gz')
 
     # Get local db config
-    db_config = YAML.load_file("#{Rails.root}/config/database.yml")
+    db_config = YAML.safe_load(File.open("#{Rails.root}/config/database.yml"), aliases: true)
 
     # Unzip production data file
     `gunzip #{Rails.root}/tmp/#{filename}.gz`
@@ -79,7 +79,7 @@ namespace :database_data do
 
     Net::SSH.start(hostname, 'deploy', port: 1855) do |ssh|
       # Pull down db config to be parsed
-      db_config = YAML.safe_load(ssh.exec!('cat rmd/current/config/database.yml'))
+      db_config = YAML.safe_load(ssh.exec!('cat rmd/current/config/database.yml'), aliases: true)
 
       # Parse values from db config
       db_password = db_config['staging']['password']
@@ -115,7 +115,7 @@ namespace :database_data do
 
     Net::SSH.start(hostname, 'deploy', port: 1855) do |ssh|
       # Pull down db config to be parsed
-      db_config = YAML.safe_load(ssh.exec!('cat rmd/current/config/database.yml'))
+      db_config = YAML.safe_load(ssh.exec!('cat rmd/current/config/database.yml'), aliases: true)
 
       # Parse values from db config
       db_password = db_config['beta']['password']

--- a/lib/tasks/email_notifications.rake
+++ b/lib/tasks/email_notifications.rake
@@ -6,9 +6,11 @@ namespace :email_notifications do
     OpenAccessNotifier.new.send_notifications
   end
 
-  desc 'Send reminder emails about potential open access publications to applicable users up to the number passed as an argument (300 as default)'
+  desc 'Send reminder emails about potential open access publications to applicable users up to the number passed as an argument (or the configured number as default)'
   task :send_capped_open_access_reminders, [:cap] => :environment do |_task, args|
-    cap = (args[:cap] || 300).to_i
+    return "Notifications are turned off" if OaNotificationSetting.is_not_active
+
+    cap = (args[:cap] || OaNotificationSetting.email_cap).to_i
     OpenAccessNotifier.new.send_notifications_with_cap(cap)
   end
 

--- a/lib/tasks/email_notifications.rake
+++ b/lib/tasks/email_notifications.rake
@@ -6,6 +6,12 @@ namespace :email_notifications do
     OpenAccessNotifier.new.send_notifications
   end
 
+  desc 'Send reminder emails about potential open access publications to applicable users up to the number passed as an argument (300 as default)'
+  task :send_capped_open_access_reminders, [:cap] => :environment do |_task, args|
+    cap = (args[:cap] || 300).to_i
+    OpenAccessNotifier.new.send_notifications_with_cap(cap)
+  end
+
   desc 'Send reminder emails about potential open access publications only to applicable users in the Penn State University Libraries'
   task send_library_open_access_reminders: :environment do
     psu_libraries = Organization.find_by(pure_external_identifier: 'CAMPUS-UL')
@@ -26,7 +32,7 @@ namespace :email_notifications do
   task :send_first_five_open_access_reminders_for_org, [:org_name] => :environment do |_task, args|
     org = Organization.find_by(pure_external_identifier: args[:org_name])
     if org
-      OpenAccessNotifier.new(org.all_users).send_first_five_notifications
+      OpenAccessNotifier.new(org.all_users).send_notifications_with_cap(5)
     else
       raise "Couldn't find an organization with Pure external identifier #{args[:org_name]}"
     end

--- a/lib/tasks/email_notifications.rake
+++ b/lib/tasks/email_notifications.rake
@@ -8,7 +8,7 @@ namespace :email_notifications do
 
   desc 'Send reminder emails about potential open access publications to applicable users up to the number passed as an argument (or the configured number as default)'
   task :send_capped_open_access_reminders, [:cap] => :environment do |_task, args|
-    return "Notifications are turned off" if OaNotificationSetting.is_not_active
+    return 'Notifications are turned off' if OaNotificationSetting.not_active?
 
     cap = (args[:cap] || OaNotificationSetting.email_cap).to_i
     OpenAccessNotifier.new.send_notifications_with_cap(cap)

--- a/spec/component/models/oa_notification_setting_spec.rb
+++ b/spec/component/models/oa_notification_setting_spec.rb
@@ -49,9 +49,16 @@ RSpec.describe OaNotificationSetting, type: :model do
 
   describe 'validation' do
     context 'when creating a record when another already exists' do
-      it 'raises an error' do
+      it 'raises a RecordNotUnique error' do
         described_class.instance
-        described_class.create email_cap: 100, is_active: true
+        expect { described_class.create email_cap: 100, is_active: true, singleton_guard: 0 }
+          .to raise_error ActiveRecord::RecordNotUnique
+      end
+    end
+
+    context 'when creating a record with a singleton_guard that is not 0' do
+      it 'raises a RecordInvalid error' do
+        expect(described_class.create(email_cap: 100, is_active: true, singleton_guard: 1).valid?).to be false
       end
     end
   end

--- a/spec/component/models/oa_notification_setting_spec.rb
+++ b/spec/component/models/oa_notification_setting_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'component/component_spec_helper'
+
+RSpec.describe OaNotificationSetting, type: :model do
+  it { is_expected.to have_db_column(:email_cap).of_type(:integer) }
+  it { is_expected.to have_db_column(:is_active).of_type(:boolean) }
+
+  before do
+    described_class.destroy_all
+  end
+
+  describe '#instance' do
+    context 'when a record already exists' do
+      it 'returns the record' do
+        setting = described_class.create(email_cap: 100, is_active: true, singleton_guard: 0)
+        expect(described_class.instance).to eq setting
+      end
+    end
+
+    context "when a record doesn't exist" do
+      it 'creates new record with seed data record' do
+        expect(described_class.instance.email_cap).to eq 300
+      end
+    end
+  end
+
+  describe '#email_cap' do
+    it "returns the first record's email_cap" do
+      setting = described_class.create(email_cap: 100, is_active: true, singleton_guard: 0)
+      expect(described_class.email_cap).to eq setting.email_cap
+    end
+  end
+
+  describe '#is_not_active' do
+    context "when first record's is_active bool is true" do
+      it "returns false" do
+        expect(described_class.is_not_active).to eq false
+      end
+    end
+
+    context "when first record's is_active bool is false" do
+      it "returns true" do
+        described_class.instance.is_active = false
+        expect(described_class.is_not_active).to eq true
+      end
+    end
+  end
+end

--- a/spec/component/models/oa_notification_setting_spec.rb
+++ b/spec/component/models/oa_notification_setting_spec.rb
@@ -3,46 +3,55 @@
 require 'component/component_spec_helper'
 
 RSpec.describe OaNotificationSetting, type: :model do
-  it { is_expected.to have_db_column(:email_cap).of_type(:integer) }
-  it { is_expected.to have_db_column(:is_active).of_type(:boolean) }
-
   before do
     described_class.destroy_all
   end
 
+  it { is_expected.to have_db_column(:email_cap).of_type(:integer) }
+  it { is_expected.to have_db_column(:is_active).of_type(:boolean) }
+
   describe '#instance' do
     context 'when a record already exists' do
       it 'returns the record' do
-        setting = described_class.create(email_cap: 100, is_active: true, singleton_guard: 0)
+        setting = described_class.create(email_cap: 300, is_active: true, singleton_guard: 0)
         expect(described_class.instance).to eq setting
       end
     end
 
     context "when a record doesn't exist" do
       it 'creates new record with seed data record' do
-        expect(described_class.instance.email_cap).to eq 300
+        expect(described_class.instance.email_cap).to eq 100
       end
     end
   end
 
   describe '#email_cap' do
     it "returns the first record's email_cap" do
-      setting = described_class.create(email_cap: 100, is_active: true, singleton_guard: 0)
+      setting = described_class.create(email_cap: 300, is_active: true, singleton_guard: 0)
       expect(described_class.email_cap).to eq setting.email_cap
     end
   end
 
-  describe '#is_not_active' do
+  describe '#not_active?' do
     context "when first record's is_active bool is true" do
-      it "returns false" do
-        expect(described_class.is_not_active).to eq false
+      it 'returns false' do
+        expect(described_class.not_active?).to be false
       end
     end
 
     context "when first record's is_active bool is false" do
-      it "returns true" do
-        described_class.instance.is_active = false
-        expect(described_class.is_not_active).to eq true
+      it 'returns true' do
+        described_class.create(email_cap: 300, is_active: false, singleton_guard: 0)
+        expect(described_class.not_active?).to be true
+      end
+    end
+  end
+
+  describe 'validation' do
+    context 'when creating a record when another already exists' do
+      it 'raises an error' do
+        described_class.instance
+        described_class.create email_cap: 100, is_active: true
       end
     end
   end

--- a/spec/component/models/open_access_notifier_spec.rb
+++ b/spec/component/models/open_access_notifier_spec.rb
@@ -137,7 +137,7 @@ describe OpenAccessNotifier do
     end
   end
 
-  describe '#send_first_five_notifications' do
+  describe '#send_notifications_with_cap' do
     let(:user_collection) { double 'user collection', needs_open_access_notification: [user1, user2, user3, user4, user5, user6] }
     let(:user3) { double 'user 3',
                          old_potential_open_access_publications: pubs1,
@@ -208,7 +208,7 @@ describe OpenAccessNotifier do
       expect(email5).to receive(:deliver_now)
       expect(email6).not_to receive(:deliver_now)
 
-      notifier.send_first_five_notifications
+      notifier.send_notifications_with_cap(5)
     end
 
     it 'records the notification for each of the first five users' do
@@ -219,7 +219,7 @@ describe OpenAccessNotifier do
       expect(user5).to receive(:record_open_access_notification)
       expect(user6).not_to receive(:record_open_access_notification)
 
-      notifier.send_first_five_notifications
+      notifier.send_notifications_with_cap(5)
     end
 
     it 'records the notification for each authorship for the first five users' do
@@ -236,7 +236,7 @@ describe OpenAccessNotifier do
       expect(auth11).not_to receive(:record_open_access_notification)
       expect(auth12).not_to receive(:record_open_access_notification)
 
-      notifier.send_first_five_notifications
+      notifier.send_notifications_with_cap(5)
     end
 
     context 'when an error is raised while sending an email' do
@@ -250,7 +250,7 @@ describe OpenAccessNotifier do
         expect(email5).to receive(:deliver_now)
         expect(email6).not_to receive(:deliver_now)
 
-        notifier.send_first_five_notifications
+        notifier.send_notifications_with_cap(5)
       end
 
       it 'records only the successful notifications for each of the first five users' do
@@ -261,7 +261,7 @@ describe OpenAccessNotifier do
         expect(user5).to receive(:record_open_access_notification)
         expect(user6).not_to receive(:record_open_access_notification)
 
-        notifier.send_first_five_notifications
+        notifier.send_notifications_with_cap(5)
       end
 
       it 'records only the successful notifications for each authorship for the first five users' do
@@ -278,13 +278,13 @@ describe OpenAccessNotifier do
         expect(auth11).not_to receive(:record_open_access_notification)
         expect(auth12).not_to receive(:record_open_access_notification)
 
-        notifier.send_first_five_notifications
+        notifier.send_notifications_with_cap(5)
       end
 
       it 'records the error' do
         expect(EmailError).to receive(:create!).with(message: 'The error message', user: user1)
 
-        notifier.send_first_five_notifications
+        notifier.send_notifications_with_cap(5)
       end
     end
   end

--- a/spec/integration/admin/oa_notification_settings/edit_spec.rb
+++ b/spec/integration/admin/oa_notification_settings/edit_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'integration/integration_spec_helper'
+require 'integration/admin/shared_examples_for_admin_page'
+
+describe 'Oa Notification Settings edit page', type: :feature do
+  let!(:settings) { OaNotificationSetting.instance }
+
+  context 'when the current user is an admin' do
+    before do
+      authenticate_admin_user
+      visit rails_admin.edit_path(model_name: :oa_notification_setting, id: settings.id)
+    end
+
+    describe 'visiting the form to edit an Oa Notification Setting' do
+      it_behaves_like 'a page with the admin layout'
+      it 'show the correct content' do
+        expect(page).to have_content 'Edit Oa notification setting'
+      end
+
+      it 'does not allow the singleton_guard value to be set' do
+        expect(page).not_to have_field 'Singleton guard'
+      end
+    end
+
+    describe 'submitting the form to update an Oa Notification Setting' do
+      before do
+        fill_in 'Email cap', with: 400
+        uncheck 'Is active'
+
+        click_button 'Save'
+      end
+
+      it 'saves the new Oa Notification Setting data' do
+        o = OaNotificationSetting.instance
+        expect(o.email_cap).to be 400
+        expect(o.is_active).to be false
+        expect(o.singleton_guard).to be 0
+      end
+    end
+  end
+
+  context 'when the current user is not an admin' do
+    before { authenticate_user }
+
+    it 'redirects back to the home page with an error message' do
+      visit rails_admin.edit_path(model_name: :oa_notification_setting, id: settings.id)
+      expect(page).to have_current_path root_path, ignore_query: true
+      expect(page).to have_content I18n.t('admin.authorization.not_authorized')
+    end
+  end
+end

--- a/spec/integration/admin/oa_notification_settings/index_spec.rb
+++ b/spec/integration/admin/oa_notification_settings/index_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'integration/integration_spec_helper'
+require 'integration/admin/shared_examples_for_admin_page'
+
+describe 'Admin Oa Notification Settings list', type: :feature do
+  context 'when the current user is an admin' do
+    before { authenticate_admin_user }
+
+    describe 'the page content' do
+      let!(:setting) { OaNotificationSetting.instance }
+
+      before { visit rails_admin.index_path(model_name: :oa_notification_setting) }
+
+      it 'shows the Oa Notification Settings list heading' do
+        expect(page).to have_content 'List of Oa notification settings'
+      end
+
+      it 'shows information about each Oa Notification Setting' do
+        expect(page).to have_content setting.email_cap
+        expect(page).to have_css 'span.label-success', exact_text: '✓', count: 1
+      end
+    end
+
+    describe 'the page layout' do
+      before { visit rails_admin.index_path(model_name: :oa_notification_setting) }
+
+      it_behaves_like 'a page with the admin layout'
+    end
+  end
+
+  context 'when the current user is not an admin' do
+    before { authenticate_user }
+
+    it 'redirects back to the home page with an error message' do
+      visit rails_admin.index_path(model_name: :oa_notification_setting)
+      expect(page).to have_current_path root_path, ignore_query: true
+      expect(page).to have_content I18n.t('admin.authorization.not_authorized')
+    end
+  end
+end

--- a/spec/integration/admin/oa_notification_settings/show_spec.rb
+++ b/spec/integration/admin/oa_notification_settings/show_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'integration/integration_spec_helper'
+require 'integration/admin/shared_examples_for_admin_page'
+
+describe 'Oa Notification Settings show page', type: :feature do
+  let!(:settings) { OaNotificationSetting.instance }
+
+  context 'when the current user is an admin' do
+    before do
+      authenticate_admin_user
+      visit rails_admin.show_path(model_name: :oa_notification_setting, id: settings.id)
+    end
+
+    describe 'visiting the page to view an Oa Notification Setting' do
+      it 'show the correct content' do
+        expect(page).to have_content 'Details for Oa notification setting'
+        expect(page).to have_content settings.email_cap
+        expect(page).to have_css 'span.label-success', exact_text: '✓', count: 1
+        expect(page).not_to have_content 'Singleton guard'
+      end
+    end
+
+    describe 'the page layout' do
+      before { visit rails_admin.show_path(model_name: :oa_notification_setting, id: settings.id) }
+
+      it_behaves_like 'a page with the admin layout'
+    end
+  end
+
+  context 'when the current user is not an admin' do
+    before { authenticate_user }
+
+    it 'redirects back to the home page with an error message' do
+      visit rails_admin.show_path(model_name: :oa_notification_setting, id: settings.id)
+      expect(page).to have_current_path root_path, ignore_query: true
+      expect(page).to have_content I18n.t('admin.authorization.not_authorized')
+    end
+  end
+end

--- a/spec/models/oa_notification_setting_spec.rb
+++ b/spec/models/oa_notification_setting_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe OaNotificationSetting, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
-end

--- a/spec/models/oa_notification_setting_spec.rb
+++ b/spec/models/oa_notification_setting_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe OaNotificationSetting, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
-Adds a singleton OaNotificationSetting class to configure the email cap for OA emails and toggle emailing on and off. 
-Implements the email cap and on/off switch
-Adds a rake task for running OA email task with the cap

closes #463 