### PR TITLE
465 update edited data

### DIFF
--- a/app/importers/activity_insight_importer.rb
+++ b/app/importers/activity_insight_importer.rb
@@ -230,20 +230,19 @@ class ActivityInsightImporter
       else
         # If the publication has been updated by an admin, we only want to
         # overwrite a subset of its attributes.
+        #byebug
         pub_record.update!(always_update_pub_attrs(ai_pub))
       end
     end
 
     def always_update_pub_attrs(pub)
-      {
-        activity_insight_postprint_status: pub.activity_insight_postprint_status
-        if pub.published?
-          status: pub.status
-        end
-        title: pub.title
-                #check if published, if so don't update; otherwise update
-                #instead check if import pub status is published?
-      }
+      attrs = {}
+      attrs[:activity_insight_postprint_status] = pub.activity_insight_postprint_status
+      if pub.status == "Published"
+        attrs[:status] = pub.status
+      end
+      attrs[:title] = pub.title
+      attrs
     end
 
     def pub_attrs(pub)

--- a/app/importers/activity_insight_importer.rb
+++ b/app/importers/activity_insight_importer.rb
@@ -230,17 +230,19 @@ class ActivityInsightImporter
       else
         # If the publication has been updated by an admin, we only want to
         # overwrite a subset of its attributes.
-        pub_record.update!(always_update_pub_attrs(ai_pub))
+        pub_record.update!(always_update_pub_attrs(ai_pub, pub_record))
       end
     end
 
-    def always_update_pub_attrs(pub)
+    def always_update_pub_attrs(pub, pub_record)
       attrs = {}
       attrs[:activity_insight_postprint_status] = pub.activity_insight_postprint_status
       if pub.status == 'Published'
         attrs[:status] = pub.status
       end
-      attrs[:title] = pub.title
+      if pub_record.has_single_import_from_ai?
+        attrs[:title] = pub.title
+      end
       attrs
     end
 

--- a/app/importers/activity_insight_importer.rb
+++ b/app/importers/activity_insight_importer.rb
@@ -237,6 +237,12 @@ class ActivityInsightImporter
     def always_update_pub_attrs(pub)
       {
         activity_insight_postprint_status: pub.activity_insight_postprint_status
+        if pub.published?
+          status: pub.status
+        end
+        title: pub.title
+                #check if published, if so don't update; otherwise update
+                #instead check if import pub status is published?
       }
     end
 

--- a/app/importers/activity_insight_importer.rb
+++ b/app/importers/activity_insight_importer.rb
@@ -230,7 +230,6 @@ class ActivityInsightImporter
       else
         # If the publication has been updated by an admin, we only want to
         # overwrite a subset of its attributes.
-        #byebug
         pub_record.update!(always_update_pub_attrs(ai_pub))
       end
     end
@@ -238,7 +237,7 @@ class ActivityInsightImporter
     def always_update_pub_attrs(pub)
       attrs = {}
       attrs[:activity_insight_postprint_status] = pub.activity_insight_postprint_status
-      if pub.status == "Published"
+      if pub.status == 'Published'
         attrs[:status] = pub.status
       end
       attrs[:title] = pub.title

--- a/app/importers/pure_publication_importer.rb
+++ b/app/importers/pure_publication_importer.rb
@@ -35,7 +35,7 @@ class PurePublicationImporter < PureImporter
                 attrs[:status] = status_value(publication)
               end
               attrs[:title] = title(publication)
-              
+
               attrs = attrs.merge(doi: doi(publication)) if p.doi.blank?
               pi.publication.update!(attrs)
             else

--- a/app/importers/pure_publication_importer.rb
+++ b/app/importers/pure_publication_importer.rb
@@ -28,14 +28,14 @@ class PurePublicationImporter < PureImporter
 
           if pi.persisted?
             if p.updated_by_user_at.present?
-              attrs = {
-                total_scopus_citations: publication['totalScopusCitations'],
-                journal: journal_present?(publication) ? journal(publication) : nil
-                if !p.published?
-                  status: status_value(publication)
-                end
-                title: title(publication)
-              }
+              attrs = {}
+              attrs[:total_scopus_citations] = publication['totalScopusCitations']
+              attrs[:journal] = journal_present?(publication) ? journal(publication) : nil
+              if !p.published?
+                attrs[:status] = status_value(publication)
+              end
+              attrs[:title] = title(publication)
+              
               attrs = attrs.merge(doi: doi(publication)) if p.doi.blank?
               pi.publication.update!(attrs)
             else

--- a/app/importers/pure_publication_importer.rb
+++ b/app/importers/pure_publication_importer.rb
@@ -31,6 +31,10 @@ class PurePublicationImporter < PureImporter
               attrs = {
                 total_scopus_citations: publication['totalScopusCitations'],
                 journal: journal_present?(publication) ? journal(publication) : nil
+                if !p.published?
+                  status: status_value(publication)
+                end
+                title: title(publication)
               }
               attrs = attrs.merge(doi: doi(publication)) if p.doi.blank?
               pi.publication.update!(attrs)
@@ -112,7 +116,7 @@ class PurePublicationImporter < PureImporter
 
     def pub_attrs(publication)
       {
-        title: publication['title']['value'] + subtitle(publication),
+        title: title(publication),
         secondary_title: nil,
         publication_type: PurePublicationTypeMapIn.map(publication['type']['term']['text']
                                                   .find { |t| t['locale'] == 'en_US' }['value']),
@@ -130,6 +134,10 @@ class PurePublicationImporter < PureImporter
         visible: true,
         doi: doi(publication)
       }
+    end
+
+    def title(publication)
+      publication['title']['value'] + subtitle(publication)
     end
 
     def subtitle(publication)

--- a/spec/component/importers/activity_insight_importer_spec.rb
+++ b/spec/component/importers/activity_insight_importer_spec.rb
@@ -752,11 +752,11 @@ describe ActivityInsightImporter do
 
       context 'when no included publications exist in the database' do
         it 'creates a new publication import record for every Published or In Press publication w/o an RMD_ID in the imported data' do
-          expect { importer.call }.to change(PublicationImport, :count).by 4
+          expect { importer.call }.to change(PublicationImport, :count).by 5
         end
 
         it 'creates a new publication record for every Published or In Press publication w/o an RMD_ID in the imported data' do
-          expect { importer.call }.to change(Publication, :count).by 4
+          expect { importer.call }.to change(Publication, :count).by 5
         end
 
         it 'saves the correct data to the new publication records' do
@@ -852,7 +852,7 @@ describe ActivityInsightImporter do
         end
 
         it 'groups duplicates of new publication records' do
-          expect { importer.call }.to change(DuplicatePublicationGroup, :count).by 1
+          expect { importer.call }.to change(DuplicatePublicationGroup, :count).by 2
 
           p1 = PublicationImport.find_by(source: 'Activity Insight',
                                          source_identifier: '190706413568').publication
@@ -872,7 +872,7 @@ describe ActivityInsightImporter do
         end
 
         it 'creates a new authorship record for every faculty author for each imported publication' do
-          expect { importer.call }.to change(Authorship, :count).by 4
+          expect { importer.call }.to change(Authorship, :count).by 5
         end
 
         it 'saves the correct attributes with each new authorship' do
@@ -906,7 +906,7 @@ describe ActivityInsightImporter do
         end
 
         it 'creates a new contributor name record for every faculty author for each imported publication' do
-          expect { importer.call }.to change(ContributorName, :count).by 9
+          expect { importer.call }.to change(ContributorName, :count).by 11
         end
 
         it 'saves the correct attributes with each new contributor name' do
@@ -984,7 +984,11 @@ describe ActivityInsightImporter do
         let!(:existing_import) { create :publication_import,
                                         source: 'Activity Insight',
                                         source_identifier: '171620739072',
-                                        publication: existing_pub }
+                                        publication: existing_pub}
+        let!(:existing_import_two) { create :publication_import,
+                                        source: 'Activity Insight',
+                                        source_identifier: '271620739072',
+                                        publication: existing_pub2}
         let(:existing_pub) { create :publication,
                                     title: 'Existing Title',
                                     publication_type: 'Trade Journal Article',
@@ -1005,6 +1009,26 @@ describe ActivityInsightImporter do
                                     updated_by_user_at: timestamp,
                                     visible: false,
                                     doi: 'https://doi.org/10.000/existing' }
+        let(:existing_pub2) { create :publication,
+                                    title: 'Existing Title 2',
+                                    publication_type: 'Trade Journal Article',
+                                    journal_title: 'Existing Journal 2',
+                                    publisher_name: 'Existing Publisher 2',
+                                    secondary_title: 'Existing Subtitle 2',
+                                    status: 'Published',
+                                    activity_insight_postprint_status: 'Cannot Deposit',
+                                    volume: '112',
+                                    issue: '223',
+                                    edition: '334',
+                                    page_range: '444-556',
+                                    url: 'existing_url2',
+                                    issn: 'existing_ISSN2',
+                                    abstract: 'Existing abstract2',
+                                    authors_et_al: true,
+                                    published_on: Date.new(1980, 2, 2),
+                                    updated_by_user_at: timestamp,
+                                    visible: false,
+                                    doi: 'https://doi.org/10.000/existing2' }
 
         context 'when the existing publication has been modified by an admin user' do
           let(:timestamp) { Time.new(2018, 10, 10, 0, 0, 0) }
@@ -1031,6 +1055,8 @@ describe ActivityInsightImporter do
                                            source_identifier: '92747188475').publication
             p4 = PublicationImport.find_by(source: 'Activity Insight',
                                            source_identifier: '190707482930').publication
+            p5 = PublicationImport.find_by(source: 'Activity Insight',
+                                          source_identifier: '271620739072').publication
 
             expect(p1.title).to eq 'First Test Publication With a Really Unique Title'
             expect(p1.publication_type).to eq 'Journal Article'
@@ -1051,12 +1077,12 @@ describe ActivityInsightImporter do
             expect(p1.updated_by_user_at).to be_nil
             expect(p1.doi).to eq 'https://doi.org/10.1186/s40168-020-00798-w'
 
-            expect(p2.title).to eq 'Existing Title'
+            expect(p2.title).to eq 'Second Test Publication'
             expect(p2.publication_type).to eq 'Trade Journal Article'
             expect(p2.journal_title).to eq 'Existing Journal'
             expect(p2.publisher_name).to eq 'Existing Publisher'
             expect(p2.secondary_title).to eq 'Existing Subtitle'
-            expect(p2.status).to eq 'In Press'
+            expect(p2.status).to eq 'Published'
             expect(p2.activity_insight_postprint_status).to eq 'In Progress'
             expect(p2.volume).to eq '111'
             expect(p2.issue).to eq '222'
@@ -1110,10 +1136,14 @@ describe ActivityInsightImporter do
             expect(p4.visible).to be true
             expect(p4.updated_by_user_at).to be_nil
             expect(p4.doi).to eq 'https://doi.org/10.1186/s40543-020-00345-w'
+
+            #testing that an 'in press' publication does not update status
+            #byebug
+            expect(p5.status).to eq 'Published'
           end
 
           it 'groups duplicates of new publication records' do
-            expect { importer.call }.to change(DuplicatePublicationGroup, :count).by 1
+            expect { importer.call }.to change(DuplicatePublicationGroup, :count).by 2
 
             p1 = PublicationImport.find_by(source: 'Activity Insight',
                                            source_identifier: '190706413568').publication
@@ -1405,7 +1435,7 @@ describe ActivityInsightImporter do
           end
 
           it 'groups duplicates of new publication records' do
-            expect { importer.call }.to change(DuplicatePublicationGroup, :count).by 1
+            expect { importer.call }.to change(DuplicatePublicationGroup, :count).by 2
 
             p1 = PublicationImport.find_by(source: 'Activity Insight',
                                            source_identifier: '190706413568').publication
@@ -1433,7 +1463,7 @@ describe ActivityInsightImporter do
             let(:user) { create :user, activity_insight_identifier: '1649499', webaccess_id: 'abc123' }
 
             it 'creates new authorship records for every new faculty author for each new imported publication' do
-              expect { importer.call }.to change(Authorship, :count).by 3
+              expect { importer.call }.to change(Authorship, :count).by 4
             end
 
             it 'saves the correct attributes with each new authorship and updates the existing authorship' do
@@ -1469,7 +1499,7 @@ describe ActivityInsightImporter do
 
           context 'when no authorships exist for the existing publication' do
             it 'creates a new authorship record for every new faculty author for each imported publication' do
-              expect { importer.call }.to change(Authorship, :count).by 4
+              expect { importer.call }.to change(Authorship, :count).by 5
             end
 
             it 'saves the correct attributes with each new authorship' do
@@ -1504,7 +1534,7 @@ describe ActivityInsightImporter do
           end
 
           it 'creates a new contributor name record for every faculty author for each imported publication' do
-            expect { importer.call }.to change(ContributorName, :count).by 8
+            expect { importer.call }.to change(ContributorName, :count).by 10
           end
 
           it 'removes any existing contributor names that are not in the new import' do
@@ -2348,11 +2378,11 @@ describe ActivityInsightImporter do
 
         context 'when no included publications exist in the database' do
           it 'creates a new publication import record for every Published or In Press publication w/o an RMD_ID in the imported data' do
-            expect { importer.call }.to change(PublicationImport, :count).by 4
+            expect { importer.call }.to change(PublicationImport, :count).by 5
           end
 
           it 'creates a new publication record for every Published or In Press publication w/o an RMD_ID in the imported data' do
-            expect { importer.call }.to change(Publication, :count).by 4
+            expect { importer.call }.to change(Publication, :count).by 5
           end
 
           it 'saves the correct data to the new publication records' do
@@ -2448,7 +2478,7 @@ describe ActivityInsightImporter do
           end
 
           it 'groups duplicates of new publication records' do
-            expect { importer.call }.to change(DuplicatePublicationGroup, :count).by 1
+            expect { importer.call }.to change(DuplicatePublicationGroup, :count).by 2
 
             p1 = PublicationImport.find_by(source: 'Activity Insight',
                                            source_identifier: '190706413568').publication
@@ -2468,7 +2498,7 @@ describe ActivityInsightImporter do
           end
 
           it 'creates a new authorship record for every faculty author for each imported publication' do
-            expect { importer.call }.to change(Authorship, :count).by 4
+            expect { importer.call }.to change(Authorship, :count).by 5
           end
 
           it 'saves the correct attributes with each new authorship' do
@@ -2502,7 +2532,7 @@ describe ActivityInsightImporter do
           end
 
           it 'creates a new contributor name record for every faculty author for each imported publication' do
-            expect { importer.call }.to change(ContributorName, :count).by 9
+            expect { importer.call }.to change(ContributorName, :count).by 11
           end
 
           it 'saves the correct attributes with each new contributor name' do
@@ -2609,11 +2639,11 @@ describe ActivityInsightImporter do
             let!(:existing_cont) { create :contributor_name, publication: existing_pub }
 
             it 'creates a new publication import record for every new Published or In Press publication w/o an RMD_ID in the imported data' do
-              expect { importer.call }.to change(PublicationImport, :count).by 3
+              expect { importer.call }.to change(PublicationImport, :count).by 4
             end
 
             it 'creates a new publication record for every new Published or In Press publication w/o an RMD_ID in the imported data' do
-              expect { importer.call }.to change(Publication, :count).by 3
+              expect { importer.call }.to change(Publication, :count).by 4
             end
 
             it 'saves the correct data to the new publication records and only updates a subset of attributes on existing records' do
@@ -2648,12 +2678,12 @@ describe ActivityInsightImporter do
               expect(p1.updated_by_user_at).to be_nil
               expect(p1.doi).to eq 'https://doi.org/10.1186/s40168-020-00798-w'
 
-              expect(p2.title).to eq 'Existing Title'
+              expect(p2.title).to eq 'Second Test Publication'
               expect(p2.publication_type).to eq 'Trade Journal Article'
               expect(p2.journal_title).to eq 'Existing Journal'
               expect(p2.publisher_name).to eq 'Existing Publisher'
               expect(p2.secondary_title).to eq 'Existing Subtitle'
-              expect(p2.status).to eq 'In Press'
+              expect(p2.status).to eq 'Published'
               expect(p2.volume).to eq '111'
               expect(p2.issue).to eq '222'
               expect(p2.edition).to eq '333'
@@ -2736,7 +2766,7 @@ describe ActivityInsightImporter do
                                                    author_number: 6 }
 
               it 'creates new authorship records for every new faculty author for each new imported publication' do
-                expect { importer.call }.to change(Authorship, :count).by 3
+                expect { importer.call }.to change(Authorship, :count).by 4
               end
 
               it 'saves the correct attributes with each new authorship and does not update the existing authorship' do
@@ -2772,7 +2802,7 @@ describe ActivityInsightImporter do
 
             context 'when no authorships exist for the existing publication' do
               it 'creates a new authorship record for every new faculty author for each new imported publication' do
-                expect { importer.call }.to change(Authorship, :count).by 3
+                expect { importer.call }.to change(Authorship, :count).by 4
               end
 
               it 'saves the correct attributes with each new authorship' do
@@ -2806,7 +2836,7 @@ describe ActivityInsightImporter do
             end
 
             it 'creates a new contributor name record for every faculty author for each new imported publication' do
-              expect { importer.call }.to change(ContributorName, :count).by 7
+              expect { importer.call }.to change(ContributorName, :count).by 9
             end
 
             it 'does not remove any existing contributor names on the existing publication' do
@@ -2902,11 +2932,11 @@ describe ActivityInsightImporter do
             let!(:existing_cont) { create :contributor_name, publication: existing_pub }
 
             it 'creates a new publication import record for every new Published or In Press publication w/o an RMD_ID in the imported data' do
-              expect { importer.call }.to change(PublicationImport, :count).by 3
+              expect { importer.call }.to change(PublicationImport, :count).by 4
             end
 
             it 'creates a new publication record for every new Published or In Press publication w/o an RMD_ID in the imported data' do
-              expect { importer.call }.to change(Publication, :count).by 3
+              expect { importer.call }.to change(Publication, :count).by 4
             end
 
             it 'saves the correct data to the new publication records and updates the existing record' do
@@ -3002,7 +3032,7 @@ describe ActivityInsightImporter do
             end
 
             it 'groups duplicates of new publication records' do
-              expect { importer.call }.to change(DuplicatePublicationGroup, :count).by 1
+              expect { importer.call }.to change(DuplicatePublicationGroup, :count).by 2
 
               p1 = PublicationImport.find_by(source: 'Activity Insight',
                                              source_identifier: '190706413568').publication
@@ -3029,7 +3059,7 @@ describe ActivityInsightImporter do
                                                    author_number: 6 }
 
               it 'creates new authorship records for every new faculty author for each new imported publication' do
-                expect { importer.call }.to change(Authorship, :count).by 3
+                expect { importer.call }.to change(Authorship, :count).by 4
               end
 
               it 'saves the correct attributes with each new authorship and updates the existing authorship' do
@@ -3065,7 +3095,7 @@ describe ActivityInsightImporter do
 
             context 'when no authorships exist for the existing publication' do
               it 'creates a new authorship record for every new faculty author for each imported publication' do
-                expect { importer.call }.to change(Authorship, :count).by 4
+                expect { importer.call }.to change(Authorship, :count).by 5
               end
 
               it 'saves the correct attributes with each new authorship' do
@@ -3100,7 +3130,7 @@ describe ActivityInsightImporter do
             end
 
             it 'creates a new contributor name record for every faculty author for each imported publication' do
-              expect { importer.call }.to change(ContributorName, :count).by 8
+              expect { importer.call }.to change(ContributorName, :count).by 10
             end
 
             it 'removes any existing contributor names that are not in the new import' do
@@ -3922,11 +3952,11 @@ describe ActivityInsightImporter do
 
         context 'when no included publications exist in the database' do
           it 'creates a new publication import record for every Published or In Press publication w/o an RMD_ID in the imported data' do
-            expect { importer.call }.to change(PublicationImport, :count).by 4
+            expect { importer.call }.to change(PublicationImport, :count).by 5
           end
 
           it 'creates a new publication record for every Published or In Press publication w/o an RMD_ID in the imported data' do
-            expect { importer.call }.to change(Publication, :count).by 4
+            expect { importer.call }.to change(Publication, :count).by 5
           end
 
           it 'saves the correct data to the new publication records' do
@@ -4022,7 +4052,7 @@ describe ActivityInsightImporter do
           end
 
           it 'groups duplicates of new publication records' do
-            expect { importer.call }.to change(DuplicatePublicationGroup, :count).by 1
+            expect { importer.call }.to change(DuplicatePublicationGroup, :count).by 2
 
             p1 = PublicationImport.find_by(source: 'Activity Insight',
                                            source_identifier: '190706413568').publication
@@ -4042,7 +4072,7 @@ describe ActivityInsightImporter do
           end
 
           it 'creates a new authorship record for every faculty author for each imported publication' do
-            expect { importer.call }.to change(Authorship, :count).by 4
+            expect { importer.call }.to change(Authorship, :count).by 5
           end
 
           it 'saves the correct attributes with each new authorship' do
@@ -4076,7 +4106,7 @@ describe ActivityInsightImporter do
           end
 
           it 'creates a new contributor name record for every faculty author for each imported publication' do
-            expect { importer.call }.to change(ContributorName, :count).by 9
+            expect { importer.call }.to change(ContributorName, :count).by 11
           end
 
           it 'saves the correct attributes with each new contributor name' do
@@ -4183,11 +4213,11 @@ describe ActivityInsightImporter do
             let!(:existing_cont) { create :contributor_name, publication: existing_pub }
 
             it 'creates a new publication import record for every new Published or In Press publication w/o an RMD_ID in the imported data' do
-              expect { importer.call }.to change(PublicationImport, :count).by 3
+              expect { importer.call }.to change(PublicationImport, :count).by 4
             end
 
             it 'creates a new publication record for every new Published or In Press publication w/o an RMD_ID in the imported data' do
-              expect { importer.call }.to change(Publication, :count).by 3
+              expect { importer.call }.to change(Publication, :count).by 4
             end
 
             it 'saves the correct data to the new publication records and only updates a subset of attributes on existing records' do
@@ -4222,12 +4252,12 @@ describe ActivityInsightImporter do
               expect(p1.updated_by_user_at).to be_nil
               expect(p1.doi).to eq 'https://doi.org/10.1186/s40168-020-00798-w'
 
-              expect(p2.title).to eq 'Existing Title'
+              expect(p2.title).to eq 'Second Test Publication'
               expect(p2.publication_type).to eq 'Trade Journal Article'
               expect(p2.journal_title).to eq 'Existing Journal'
               expect(p2.publisher_name).to eq 'Existing Publisher'
               expect(p2.secondary_title).to eq 'Existing Subtitle'
-              expect(p2.status).to eq 'In Press'
+              expect(p2.status).to eq 'Published'
               expect(p2.volume).to eq '111'
               expect(p2.issue).to eq '222'
               expect(p2.edition).to eq '333'
@@ -4310,7 +4340,7 @@ describe ActivityInsightImporter do
                                                    author_number: 6 }
 
               it 'creates new authorship records for every new faculty author for each new imported publication' do
-                expect { importer.call }.to change(Authorship, :count).by 3
+                expect { importer.call }.to change(Authorship, :count).by 4
               end
 
               it 'saves the correct attributes with each new authorship and does not update the existing authorship' do
@@ -4346,7 +4376,7 @@ describe ActivityInsightImporter do
 
             context 'when no authorships exist for the existing publication' do
               it 'creates a new authorship record for every new faculty author for each new imported publication' do
-                expect { importer.call }.to change(Authorship, :count).by 3
+                expect { importer.call }.to change(Authorship, :count).by 4
               end
 
               it 'saves the correct attributes with each new authorship' do
@@ -4380,7 +4410,7 @@ describe ActivityInsightImporter do
             end
 
             it 'creates a new contributor name record for every faculty author for each new imported publication' do
-              expect { importer.call }.to change(ContributorName, :count).by 7
+              expect { importer.call }.to change(ContributorName, :count).by 9
             end
 
             it 'does not remove any existing contributor names on the existing publication' do
@@ -4475,11 +4505,11 @@ describe ActivityInsightImporter do
             let!(:existing_cont) { create :contributor_name, publication: existing_pub }
 
             it 'creates a new publication import record for every new Published or In Press publication w/o an RMD_ID in the imported data' do
-              expect { importer.call }.to change(PublicationImport, :count).by 3
+              expect { importer.call }.to change(PublicationImport, :count).by 4
             end
 
             it 'creates a new publication record for every new Published or In Press publication w/o an RMD_ID in the imported data' do
-              expect { importer.call }.to change(Publication, :count).by 3
+              expect { importer.call }.to change(Publication, :count).by 4
             end
 
             it 'saves the correct data to the new publication records and updates the existing record' do
@@ -4575,7 +4605,7 @@ describe ActivityInsightImporter do
             end
 
             it 'groups duplicates of new publication records' do
-              expect { importer.call }.to change(DuplicatePublicationGroup, :count).by 1
+              expect { importer.call }.to change(DuplicatePublicationGroup, :count).by 2
 
               p1 = PublicationImport.find_by(source: 'Activity Insight',
                                              source_identifier: '190706413568').publication
@@ -4602,7 +4632,7 @@ describe ActivityInsightImporter do
                                                    author_number: 6 }
 
               it 'creates new authorship records for every new faculty author for each new imported publication' do
-                expect { importer.call }.to change(Authorship, :count).by 3
+                expect { importer.call }.to change(Authorship, :count).by 4
               end
 
               it 'saves the correct attributes with each new authorship and updates the existing authorship' do
@@ -4638,7 +4668,7 @@ describe ActivityInsightImporter do
 
             context 'when no authorships already exist for the existing publication' do
               it 'creates a new authorship record for every new faculty author for each imported publication' do
-                expect { importer.call }.to change(Authorship, :count).by 4
+                expect { importer.call }.to change(Authorship, :count).by 5
               end
 
               it 'saves the correct attributes with each new authorship' do
@@ -4673,7 +4703,7 @@ describe ActivityInsightImporter do
             end
 
             it 'creates a new contributor name record for every faculty author for each imported publication' do
-              expect { importer.call }.to change(ContributorName, :count).by 8
+              expect { importer.call }.to change(ContributorName, :count).by 10
             end
 
             it 'removes any existing contributor names that are not in the new import' do
@@ -4841,7 +4871,7 @@ describe ActivityInsightImporter do
 
         it 'logs errors to ImporterErrorLog' do
           if import == 'Publication'
-            expect { importer.call }.to change(ImporterErrorLog, :count).by 4
+            expect { importer.call }.to change(ImporterErrorLog, :count).by 5
           else
             expect { importer.call }.to change(ImporterErrorLog, :count).by 2
           end

--- a/spec/component/importers/activity_insight_importer_spec.rb
+++ b/spec/component/importers/activity_insight_importer_spec.rb
@@ -986,9 +986,9 @@ describe ActivityInsightImporter do
                                         source_identifier: '171620739072',
                                         publication: existing_pub}
         let!(:existing_import_two) { create :publication_import,
-                                        source: 'Activity Insight',
-                                        source_identifier: '271620739072',
-                                        publication: existing_pub2}
+                                            source: 'Activity Insight',
+                                            source_identifier: '271620739072',
+                                            publication: existing_pub2}
         let(:existing_pub) { create :publication,
                                     title: 'Existing Title',
                                     publication_type: 'Trade Journal Article',
@@ -1010,25 +1010,25 @@ describe ActivityInsightImporter do
                                     visible: false,
                                     doi: 'https://doi.org/10.000/existing' }
         let(:existing_pub2) { create :publication,
-                                    title: 'Existing Title 2',
-                                    publication_type: 'Trade Journal Article',
-                                    journal_title: 'Existing Journal 2',
-                                    publisher_name: 'Existing Publisher 2',
-                                    secondary_title: 'Existing Subtitle 2',
-                                    status: 'Published',
-                                    activity_insight_postprint_status: 'Cannot Deposit',
-                                    volume: '112',
-                                    issue: '223',
-                                    edition: '334',
-                                    page_range: '444-556',
-                                    url: 'existing_url2',
-                                    issn: 'existing_ISSN2',
-                                    abstract: 'Existing abstract2',
-                                    authors_et_al: true,
-                                    published_on: Date.new(1980, 2, 2),
-                                    updated_by_user_at: timestamp,
-                                    visible: false,
-                                    doi: 'https://doi.org/10.000/existing2' }
+                                     title: 'Existing Title 2',
+                                     publication_type: 'Trade Journal Article',
+                                     journal_title: 'Existing Journal 2',
+                                     publisher_name: 'Existing Publisher 2',
+                                     secondary_title: 'Existing Subtitle 2',
+                                     status: 'Published',
+                                     activity_insight_postprint_status: 'Cannot Deposit',
+                                     volume: '112',
+                                     issue: '223',
+                                     edition: '334',
+                                     page_range: '444-556',
+                                     url: 'existing_url2',
+                                     issn: 'existing_ISSN2',
+                                     abstract: 'Existing abstract2',
+                                     authors_et_al: true,
+                                     published_on: Date.new(1980, 2, 2),
+                                     updated_by_user_at: timestamp,
+                                     visible: false,
+                                     doi: 'https://doi.org/10.000/existing2' }
 
         context 'when the existing publication has been modified by an admin user' do
           let(:timestamp) { Time.new(2018, 10, 10, 0, 0, 0) }
@@ -1056,7 +1056,7 @@ describe ActivityInsightImporter do
             p4 = PublicationImport.find_by(source: 'Activity Insight',
                                            source_identifier: '190707482930').publication
             p5 = PublicationImport.find_by(source: 'Activity Insight',
-                                          source_identifier: '271620739072').publication
+                                           source_identifier: '271620739072').publication
 
             expect(p1.title).to eq 'First Test Publication With a Really Unique Title'
             expect(p1.publication_type).to eq 'Journal Article'
@@ -1137,8 +1137,7 @@ describe ActivityInsightImporter do
             expect(p4.updated_by_user_at).to be_nil
             expect(p4.doi).to eq 'https://doi.org/10.1186/s40543-020-00345-w'
 
-            #testing that an 'in press' publication does not update status
-            #byebug
+            # testing that an 'in press' publication does not update status
             expect(p5.status).to eq 'Published'
           end
 

--- a/spec/component/importers/pure_publication_importer_spec.rb
+++ b/spec/component/importers/pure_publication_importer_spec.rb
@@ -238,10 +238,10 @@ describe PurePublicationImporter do
                                         source_updated_at: Time.new(1999, 12, 31, 23, 59, 59),
                                         publication: existing_pub }
         let!(:existing_import2) { create :publication_import,
-                                        source: 'Pure',
-                                        source_identifier: 'e1b21d75-4579-4efc-9fcc-dcd9827ee51b',
-                                        source_updated_at: Time.new(1999, 12, 30, 23, 59, 59),
-                                        publication: existing_pub2 }
+                                         source: 'Pure',
+                                         source_identifier: 'e1b21d75-4579-4efc-9fcc-dcd9827ee51b',
+                                         source_updated_at: Time.new(1999, 12, 30, 23, 59, 59),
+                                         publication: existing_pub2 }
         let(:existing_pub) { create :publication,
                                     updated_by_user_at: updated_ts,
                                     title: 'Existing Title',
@@ -259,21 +259,21 @@ describe PurePublicationImporter do
                                     visible: false,
                                     doi: doi }
         let(:existing_pub2) { create :publication,
-                                    updated_by_user_at: updated_ts,
-                                    title: 'Existing Title2',
-                                    secondary_title: 'Existing Subtitle2',
-                                    publication_type: 'Journal Article',
-                                    journal: existing_journal,
-                                    page_range: 'existing range2',
-                                    volume: 'existing volume2',
-                                    issue: 'existing issue2',
-                                    issn: 'existing issn2',
-                                    status: 'Published',
-                                    published_on: Date.new(2018, 9, 22),
-                                    total_scopus_citations: 1,
-                                    abstract: 'existing abstract2',
-                                    visible: false,
-                                    doi: doi2 }
+                                     updated_by_user_at: updated_ts,
+                                     title: 'Existing Title2',
+                                     secondary_title: 'Existing Subtitle2',
+                                     publication_type: 'Journal Article',
+                                     journal: existing_journal,
+                                     page_range: 'existing range2',
+                                     volume: 'existing volume2',
+                                     issue: 'existing issue2',
+                                     issn: 'existing issn2',
+                                     status: 'Published',
+                                     published_on: Date.new(2018, 9, 22),
+                                     total_scopus_citations: 1,
+                                     abstract: 'existing abstract2',
+                                     visible: false,
+                                     doi: doi2 }
         let(:doi) { 'https://doi.org/10.000/existing' }
         let(:doi2) { 'https://doi.org/10.000/existing2' }
         let(:existing_journal) { create :journal }
@@ -537,7 +537,7 @@ describe PurePublicationImporter do
               expect(existing_pub_reloaded.visible).to be false
               expect(existing_pub_reloaded.doi).to eq 'https://doi.org/10.000/existing'
 
-              expect(existing_pub2_reloaded.status).to eq 'Published' 
+              expect(existing_pub2_reloaded.status).to eq 'Published'
             end
           end
 

--- a/spec/component/importers/pure_publication_importer_spec.rb
+++ b/spec/component/importers/pure_publication_importer_spec.rb
@@ -18,6 +18,7 @@ describe PurePublicationImporter do
   let(:found_pub1) { PublicationImport.find_by(source: 'Pure', source_identifier: 'e1b21d75-4579-4efc-9fcc-dcd9827ee51a') }
   let(:found_pub2) { PublicationImport.find_by(source: 'Pure', source_identifier: 'bfc570c3-10d8-451e-9145-c370d6f01c64') }
   let(:found_pub3) { PublicationImport.find_by(source: 'Pure', source_identifier: 'fc65cb12-5a98-477e-b2f8-e191e0aae9d0') }
+  let(:found_pub4) { PublicationImport.find_by(source: 'Pure', source_identifier: 'e1b21d75-4579-4efc-9fcc-dcd9827ee51b') }
 
   let!(:journal) { create :journal,
                           pure_uuid: '6bd3ad47-c2bf-44cb-9d79-85d9fe14550f' }
@@ -37,19 +38,19 @@ describe PurePublicationImporter do
     context 'when the API endpoint is found' do
       context 'when no publication import records exist in the database' do
         it 'creates a new publication import record for each Published or Accepted/In press publication in the imported data' do
-          expect { importer.call }.to change(PublicationImport, :count).by 3
+          expect { importer.call }.to change(PublicationImport, :count).by 4
         end
 
         it 'creates a new publication record for each Published or Accepted/In press publication in the imported data' do
-          expect { importer.call }.to change(Publication, :count).by 3
+          expect { importer.call }.to change(Publication, :count).by 4
         end
 
         it 'creates a new contributor name record for each author on each publication' do
-          expect { importer.call }.to change(ContributorName, :count).by 11
+          expect { importer.call }.to change(ContributorName, :count).by 13
         end
 
         it 'creates a new authorship record for each author who is a Penn State user on each publication' do
-          expect { importer.call }.to change(Authorship, :count).by 3
+          expect { importer.call }.to change(Authorship, :count).by 4
         end
 
         it 'saves the correct data for each publication import' do
@@ -236,6 +237,11 @@ describe PurePublicationImporter do
                                         source_identifier: 'e1b21d75-4579-4efc-9fcc-dcd9827ee51a',
                                         source_updated_at: Time.new(1999, 12, 31, 23, 59, 59),
                                         publication: existing_pub }
+        let!(:existing_import2) { create :publication_import,
+                                        source: 'Pure',
+                                        source_identifier: 'e1b21d75-4579-4efc-9fcc-dcd9827ee51b',
+                                        source_updated_at: Time.new(1999, 12, 30, 23, 59, 59),
+                                        publication: existing_pub2 }
         let(:existing_pub) { create :publication,
                                     updated_by_user_at: updated_ts,
                                     title: 'Existing Title',
@@ -252,7 +258,24 @@ describe PurePublicationImporter do
                                     abstract: 'existing abstract',
                                     visible: false,
                                     doi: doi }
+        let(:existing_pub2) { create :publication,
+                                    updated_by_user_at: updated_ts,
+                                    title: 'Existing Title2',
+                                    secondary_title: 'Existing Subtitle2',
+                                    publication_type: 'Journal Article',
+                                    journal: existing_journal,
+                                    page_range: 'existing range2',
+                                    volume: 'existing volume2',
+                                    issue: 'existing issue2',
+                                    issn: 'existing issn2',
+                                    status: 'Published',
+                                    published_on: Date.new(2018, 9, 22),
+                                    total_scopus_citations: 1,
+                                    abstract: 'existing abstract2',
+                                    visible: false,
+                                    doi: doi2 }
         let(:doi) { 'https://doi.org/10.000/existing' }
+        let(:doi2) { 'https://doi.org/10.000/existing2' }
         let(:existing_journal) { create :journal }
 
         context 'when the existing publication record has not been manually updated' do
@@ -268,7 +291,7 @@ describe PurePublicationImporter do
 
           context 'when no contributor records exist' do
             it 'creates a new contributor record for each author on each publication' do
-              expect { importer.call }.to change(ContributorName, :count).by 11
+              expect { importer.call }.to change(ContributorName, :count).by 13
               expect(existing_pub.contributor_names.count).to eq 2
 
               expect(existing_pub.contributor_names.find_by(first_name: 'Firstpub R.',
@@ -293,7 +316,7 @@ describe PurePublicationImporter do
                                                  publication: existing_pub }
 
             it 'replaces the existing contributor records with new records from the import data' do
-              expect { importer.call }.to change(ContributorName, :count).by 10
+              expect { importer.call }.to change(ContributorName, :count).by 12
               expect(existing_pub.contributor_names.count).to eq 2
 
               expect(existing_pub.contributor_names.find_by(first_name: 'Firstpub R.',
@@ -311,7 +334,7 @@ describe PurePublicationImporter do
 
           context 'when no authorship records exist' do
             it 'creates a new authorship record for each author who is a Penn State user on each publication' do
-              expect { importer.call }.to change(Authorship, :count).by 3
+              expect { importer.call }.to change(Authorship, :count).by 4
 
               expect(Authorship.find_by(publication: found_pub1.publication,
                                         user: pub1auth1,
@@ -337,7 +360,7 @@ describe PurePublicationImporter do
                                           author_number: 6 }
 
             it 'does not create a new authorship record' do
-              expect { importer.call }.to change(Authorship, :count).by 2
+              expect { importer.call }.to change(Authorship, :count).by 3
             end
 
             it 'updates the existing authorship record with the new authorship data' do
@@ -493,12 +516,13 @@ describe PurePublicationImporter do
           end
 
           context 'when the existing publication already has a DOI' do
-            it 'updates only the Scopus citation count on the existing publication' do
+            it 'updates only the Scopus citation count, title, and status on the existing publication' do
               importer.call
 
               existing_pub_reloaded = existing_pub.reload
+              existing_pub2_reloaded = existing_pub2.reload
 
-              expect(existing_pub_reloaded.title).to eq 'Existing Title'
+              expect(existing_pub_reloaded.title).to eq 'The First Publication: From Pure'
               expect(existing_pub_reloaded.secondary_title).to eq 'Existing Subtitle'
               expect(existing_pub_reloaded.publication_type).to eq 'Journal Article'
               expect(existing_pub_reloaded.page_range).to eq 'existing range'
@@ -506,12 +530,14 @@ describe PurePublicationImporter do
               expect(existing_pub_reloaded.issue).to eq 'existing issue'
               expect(existing_pub_reloaded.journal).to eq new_journal
               expect(existing_pub_reloaded.issn).to eq 'existing issn'
-              expect(existing_pub_reloaded.status).to eq 'In Press'
+              expect(existing_pub_reloaded.status).to eq 'Published'
               expect(existing_pub_reloaded.published_on).to eq Date.new(2018, 8, 22)
               expect(existing_pub_reloaded.total_scopus_citations).to eq 2
               expect(existing_pub_reloaded.abstract).to eq 'existing abstract'
               expect(existing_pub_reloaded.visible).to be false
               expect(existing_pub_reloaded.doi).to eq 'https://doi.org/10.000/existing'
+
+              expect(existing_pub2_reloaded.status).to eq 'Published' 
             end
           end
 
@@ -523,7 +549,7 @@ describe PurePublicationImporter do
 
               existing_pub_reloaded = existing_pub.reload
 
-              expect(existing_pub_reloaded.title).to eq 'Existing Title'
+              expect(existing_pub_reloaded.title).to eq 'The First Publication: From Pure'
               expect(existing_pub_reloaded.secondary_title).to eq 'Existing Subtitle'
               expect(existing_pub_reloaded.publication_type).to eq 'Journal Article'
               expect(existing_pub_reloaded.page_range).to eq 'existing range'
@@ -531,7 +557,7 @@ describe PurePublicationImporter do
               expect(existing_pub_reloaded.issue).to eq 'existing issue'
               expect(existing_pub_reloaded.journal).to eq new_journal
               expect(existing_pub_reloaded.issn).to eq 'existing issn'
-              expect(existing_pub_reloaded.status).to eq 'In Press'
+              expect(existing_pub_reloaded.status).to eq 'Published'
               expect(existing_pub_reloaded.published_on).to eq Date.new(2018, 8, 22)
               expect(existing_pub_reloaded.total_scopus_citations).to eq 2
               expect(existing_pub_reloaded.abstract).to eq 'existing abstract'

--- a/spec/fixtures/activity_insight_user_abc123.xml
+++ b/spec/fixtures/activity_insight_user_abc123.xml
@@ -512,6 +512,98 @@
       <RMD_ID/>
       <USER_REFERENCE_CREATOR>Yes</USER_REFERENCE_CREATOR>
     </INTELLCONT>
+
+    <INTELLCONT id="271620739072" dmd:originalSource="BIBTEX" dmd:created="2018-11-01T14:52:45" dmd:lastModifiedSource="MANUAL" dmd:lastModified="2020-01-20T15:38:27" dmd:startDate="2019-01-01" dmd:endDate="2019-12-31">
+      <CONTYPE>Journal Article, In House</CONTYPE>
+      <CONTYPEOTHER>Journal Article</CONTYPEOTHER>
+      <TITLE>
+        Second Test Publication In Press
+      </TITLE>
+      <JOURNAL_NAME>Test Journal 2</JOURNAL_NAME>
+      <TITLE_SECONDARY>
+        Second Pub Subtitle
+      </TITLE_SECONDARY>
+      <STATUS>In Press</STATUS>
+      <REFEREED>Yes</REFEREED>
+      <INTELLCONT_AUTH id="271620739073">
+        <FACULTY_NAME>1649499</FACULTY_NAME>
+        <FNAME>Sally</FNAME>
+        <MNAME/>
+        <LNAME>Testuser</LNAME>
+        <INSTITUTION/>
+        <STATUS/>
+        <ROLE>Primary Author</ROLE>
+        <PERCENT/>
+      </INTELLCONT_AUTH>
+      <INTELLCONT_AUTH id="271620739074">
+        <FACULTY_NAME/>
+        <FNAME>B.</FNAME>
+        <MNAME/>
+        <LNAME>Tester</LNAME>
+        <INSTITUTION/>
+        <STATUS/>
+        <ROLE>Author</ROLE>
+        <PERCENT/>
+      </INTELLCONT_AUTH>
+      <AUTHORS_ETAL/>
+      <PUBLISHER/>
+      <PUBCTYST/>
+      <PUBCNTRY/>
+      <VOLUME>7</VOLUME>
+      <ISSUE/>
+      <EDITION/>
+      <PAGENUM/>
+      <PUB_PAGENUM/>
+      <WEB_ADDRESS>https://doi.org/10.1001/amajethics.2019.239</WEB_ADDRESS>
+      <FORMAT/>
+      <EDITORS/>
+      <ISBNISSN/>
+      <PMCID/>
+      <PROCEED_LOCATION/>
+      <ABSTRACT/>
+      <COMMENT/>
+      <CITATION_COUNT/>
+      <CITATION_SOURCE/>
+      <DTM_CITATION/>
+      <DTD_CITATION/>
+      <DTY_CITATION/>
+      <CITATION_START/>
+      <CITATION_END/>
+      <INTELLCONT_COUNTRY id="271620739078">
+        <COUNTRY/>
+      </INTELLCONT_COUNTRY>
+      <DESC_INTERNATIONAL/>
+      <RESEARCH_PROJECT/>
+      <INTELLCONT_FILE id="271620739079">
+        <FULL_TEXT/>
+      </INTELLCONT_FILE>
+      <POST_FILE id="271620739080">
+        <DOC/>
+        <ACCESIBLE>In Progress</ACCESIBLE>
+      </POST_FILE>
+      <DTM_EXPSUB/>
+      <DTD_EXPSUB/>
+      <DTY_EXPSUB/>
+      <EXPSUB_START/>
+      <EXPSUB_END/>
+      <DTM_SUB/>
+      <DTD_SUB/>
+      <DTY_SUB/>
+      <SUB_START/>
+      <SUB_END/>
+      <DTM_ACC/>
+      <DTY_ACC/>
+      <ACC_START/>
+      <ACC_END/>
+      <DTM_PUB/>
+      <DTD_PUB/>
+      <DTY_PUB>2019</DTY_PUB>
+      <PUB_START>2019-01-01</PUB_START>
+      <PUB_END>2019-12-31</PUB_END>
+      <RMD_ID/>
+      <USER_REFERENCE_CREATOR>Yes</USER_REFERENCE_CREATOR>
+    </INTELLCONT>
+
     <INTELLCONT id="837619053822" dmd:originalSource="WEB_OF_SCIENCE_LITE" dmd:created="2016-08-15T15:29:29" dmd:lastModifiedSource="WEB_OF_SCIENCE" dmd:wosUid="WOS:0003457423343" dmd:lastModified="2016-08-15T15:29:29" dmd:startDate="2016-01-01" dmd:endDate="2016-12-31">
       <CONTYPE>Journal Article</CONTYPE>
       <CONTYPEOTHER/>

--- a/spec/fixtures/activity_insight_user_abc123.xml
+++ b/spec/fixtures/activity_insight_user_abc123.xml
@@ -900,6 +900,10 @@
       <CITATION_END/>
       <DESC_INTERNATIONAL/>
       <RESEARCH_PROJECT/>
+      <POST_FILE id="271620739081">
+        <DOC/>
+        <ACCESIBLE>In Progress</ACCESIBLE>
+      </POST_FILE>
       <DTM_EXPSUB/>
       <DTD_EXPSUB/>
       <DTY_EXPSUB/>

--- a/spec/fixtures/pure_publications_2.json
+++ b/spec/fixtures/pure_publications_2.json
@@ -1322,6 +1322,645 @@
       }
     ]
   },{
+    "pureId": 9477897,
+    "externalId": "0031523977",
+    "externalIdSource": "Scopus",
+    "uuid": "e1b21d75-4579-4efc-9fcc-dcd9827ee51b",
+    "title": {
+      "formatted": true,
+      "value": "The First Publication Part 2"
+    },
+    "subTitle": {
+      "formatted": true,
+      "value": "From Pure"
+    },
+    "peerReview": true,
+    "numberOfPages": 5,
+    "managingOrganisationalUnit": {
+      "uuid": "f3ebd910-8783-42f0-ad1f-ba760de1d08c",
+      "externalId": "DEPT-COL-LA-PSYCH",
+      "externalIdSource": "synchronisedOrganisation",
+      "externallyManaged": true,
+      "name": {
+        "formatted": false,
+        "text": [
+          {
+            "locale": "en_US",
+            "value": "Psychology"
+          }
+        ]
+      },
+      "type": {
+        "pureId": 855,
+        "uri": "/dk/atira/pure/organisation/organisationtypes/organisation/department",
+        "term": {
+          "formatted": false,
+          "text": [
+            {
+              "locale": "en_US",
+              "value": "Department"
+            }
+          ]
+        }
+      }
+    },
+    "confidential": false,
+    "info": {
+      "createdBy": "root",
+      "createdDate": "2017-01-10T21:23:16.508+0000",
+      "modifiedBy": "sync_user",
+      "modifiedDate": "2018-03-14T20:47:06.357+0000",
+      "portalUrl": "https://pennstate.pure.elsevier.com/en/publications/e1b21d75-4579-4efc-9fcc-dcd9827ee51b",
+      "prettyURLIdentifiers": [
+        "psychotherapy-integration-and-the-need-for-better-theories-of-cha"
+      ],
+      "additionalExternalIds": [
+        {
+          "value": "0031523977",
+          "idSource": "QABO"
+        }
+      ]
+    },
+    "totalScopusCitations": 2,
+    "pages": "91-95",
+    "volume": "6",
+    "journalAssociation": {
+      "pureId": 9477896,
+      "title": {
+        "value": "Applied and Preventive Psychology"
+      },
+      "issn": {
+        "value": "0962-1849"
+      },
+      "journal": {
+        "uuid": "e72f86d9-88a4-4dea-9b0a-8cb1cccb82ad",
+        "externalId": "12023",
+        "externalIdSource": "Scopus",
+        "externallyManaged": true,
+        "name": {
+          "formatted": false,
+          "text": [
+            {
+              "value": "Applied and Preventive Psychology"
+            }
+          ]
+        },
+        "type": {
+          "pureId": 910,
+          "uri": "/dk/atira/pure/journal/journaltypes/journal/journal",
+          "term": {
+            "formatted": false,
+            "text": [
+              {
+                "locale": "en_US",
+                "value": "Journal"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "journalNumber": "2",
+    "type": {
+      "pureId": 4664,
+      "uri": "/dk/atira/pure/researchoutput/researchoutputtypes/contributiontojournal/article",
+      "term": {
+        "formatted": false,
+        "text": [
+          {
+            "locale": "en_US",
+            "value": "Article"
+          }
+        ]
+      }
+    },
+    "category": {
+      "pureId": 6885,
+      "uri": "/dk/atira/pure/researchoutput/category/research",
+      "term": {
+        "formatted": false,
+        "text": [
+          {
+            "locale": "en_US",
+            "value": "Research"
+          }
+        ]
+      }
+    },
+    "language": {
+      "pureId": 9423172,
+      "uri": "/dk/atira/pure/core/languages/en_US",
+      "term": {
+        "formatted": false,
+        "text": [
+          {
+            "locale": "en_US",
+            "value": "English (US)"
+          }
+        ]
+      }
+    },
+    "totalNumberOfAuthors": 2,
+    "openAccessPermission": {
+      "pureId": 3436171,
+      "uri": "/dk/atira/pure/researchoutput/openaccesspermission/indeterminate",
+      "term": {
+        "formatted": false,
+        "text": [
+          {
+            "locale": "en_US",
+            "value": "Indeterminate"
+          }
+        ]
+      }
+    },
+    "visibility": {
+      "key": "FREE",
+      "value": {
+        "formatted": false,
+        "text": [
+          {
+            "locale": "en_US",
+            "value": "Public - No restriction"
+          }
+        ]
+      }
+    },
+    "workflow": {
+      "workflowStep": "approved",
+      "value": {
+        "formatted": false,
+        "text": [
+          {
+            "locale": "en_US",
+            "value": "Validated"
+          }
+        ]
+      }
+    },
+    "publicationStatuses": [
+      {
+        "pureId": 9477897,
+        "externalId": "0031523977",
+        "externalIdSource": "Scopus",
+        "current": true,
+        "publicationDate": {
+          "year": 1997,
+          "month": 1,
+          "day": 1
+        },
+        "publicationStatus": {
+          "pureId": 798,
+          "uri": "/dk/atira/pure/researchoutput/status/published",
+          "term": {
+            "formatted": false,
+            "text": [
+              {
+                "locale": "en_US",
+                "value": "Accepted/In press"
+              }
+            ]
+          }
+        }
+      }
+    ],
+    "personAssociations": [
+      {
+        "pureId": 52285401,
+        "person": {
+          "uuid": "5ec8ce05-0912-4d68-8633-c5618a3cf15d",
+          "externalId": "LGC3",
+          "externalIdSource": "synchronisedPerson",
+          "externallyManaged": true,
+          "name": {
+            "formatted": false,
+            "text": [
+              {
+                "value": "Firstpub Robert Firstauthor"
+              }
+            ]
+          }
+        },
+        "name": {
+          "firstName": "Firstpub R.",
+          "lastName": "Firstauthor"
+        },
+        "personRole": {
+          "pureId": 4891,
+          "uri": "/dk/atira/pure/researchoutput/roles/contributiontojournal/author",
+          "term": {
+            "formatted": false,
+            "text": [
+              {
+                "locale": "en_US",
+                "value": "Author"
+              }
+            ]
+          }
+        },
+        "organisationalUnits": [
+          {
+            "uuid": "f3ebd910-8783-42f0-ad1f-ba760de1d08c",
+            "externalId": "DEPT-COL-LA-PSYCH",
+            "externalIdSource": "synchronisedOrganisation",
+            "externallyManaged": true,
+            "name": {
+              "formatted": false,
+              "text": [
+                {
+                  "locale": "en_US",
+                  "value": "Psychology"
+                }
+              ]
+            },
+            "type": {
+              "pureId": 855,
+              "uri": "/dk/atira/pure/organisation/organisationtypes/organisation/department",
+              "term": {
+                "formatted": false,
+                "text": [
+                  {
+                    "locale": "en_US",
+                    "value": "Department"
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      },
+      {
+        "pureId": 52285403,
+        "externalPerson": {
+          "uuid": "a33bd846-afe5-4852-851e-7b7201af5fe5",
+          "name": {
+            "formatted": false,
+            "text": [
+              {
+                "value": "Firstpub Secondauthor"
+              }
+            ]
+          },
+          "type": {
+            "pureId": 4855,
+            "uri": "/dk/atira/pure/externalperson/externalpersontypes/externalperson/externalperson",
+            "term": {
+              "formatted": false,
+              "text": [
+                {
+                  "locale": "en_US",
+                  "value": "External person"
+                }
+              ]
+            }
+          }
+        },
+        "name": {
+          "firstName": "Firstpub",
+          "lastName": "Secondauthor"
+        },
+        "personRole": {
+          "pureId": 4891,
+          "uri": "/dk/atira/pure/researchoutput/roles/contributiontojournal/author",
+          "term": {
+            "formatted": false,
+            "text": [
+              {
+                "locale": "en_US",
+                "value": "Author"
+              }
+            ]
+          }
+        },
+        "externalOrganisations": [
+          {
+            "uuid": "6abde63e-002f-4b2a-96ad-ff3039c49ea1",
+            "externalId": "508225",
+            "externalIdSource": "scival",
+            "externallyManaged": true,
+            "name": {
+              "formatted": false,
+              "text": [
+                {
+                  "locale": "en_US",
+                  "value": "Stony Brook University"
+                }
+              ]
+            },
+            "type": {
+              "pureId": 3438682,
+              "uri": "/dk/atira/pure/ueoexternalorganisation/ueoexternalorganisationtypes/ueoexternalorganisation/academic",
+              "term": {
+                "formatted": false,
+                "text": [
+                  {
+                    "locale": "en_US",
+                    "value": "Academic"
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "organisationalUnits": [
+      {
+        "uuid": "f3ebd910-8783-42f0-ad1f-ba760de1d08c",
+        "externalId": "DEPT-COL-LA-PSYCH",
+        "externalIdSource": "synchronisedOrganisation",
+        "externallyManaged": true,
+        "name": {
+          "formatted": false,
+          "text": [
+            {
+              "locale": "en_US",
+              "value": "Psychology"
+            }
+          ]
+        },
+        "type": {
+          "pureId": 855,
+          "uri": "/dk/atira/pure/organisation/organisationtypes/organisation/department",
+          "term": {
+            "formatted": false,
+            "text": [
+              {
+                "locale": "en_US",
+                "value": "Department"
+              }
+            ]
+          }
+        }
+      }
+    ],
+    "externalOrganisations": [
+      {
+        "uuid": "6abde63e-002f-4b2a-96ad-ff3039c49ea1",
+        "externalId": "508225",
+        "externalIdSource": "scival",
+        "externallyManaged": true,
+        "name": {
+          "formatted": false,
+          "text": [
+            {
+              "locale": "en_US",
+              "value": "Stony Brook University"
+            }
+          ]
+        },
+        "type": {
+          "pureId": 3438682,
+          "uri": "/dk/atira/pure/ueoexternalorganisation/ueoexternalorganisationtypes/ueoexternalorganisation/academic",
+          "term": {
+            "formatted": false,
+            "text": [
+              {
+                "locale": "en_US",
+                "value": "Academic"
+              }
+            ]
+          }
+        }
+      }
+    ],
+    "electronicVersions": [
+      {
+        "pureId": 34576011,
+        "doi": "https://doi.org/10.1016/S0\u200b962-1849(05)80014-0",
+        "accessType": {
+          "pureId": 20055478,
+          "uri": "/dk/atira/pure/core/openaccesspermission/unknown",
+          "term": {
+            "formatted": false,
+            "text": [
+              {
+                "locale": "en_US",
+                "value": "Unknown"
+              }
+            ]
+          }
+        },
+        "versionType": {
+          "pureId": 3436203,
+          "uri": "/dk/atira/pure/researchoutput/electronicversion/versiontype/publishersversion",
+          "term": {
+            "formatted": false,
+            "text": [
+              {
+                "locale": "en_US",
+                "value": "Final published version"
+              }
+            ]
+          }
+        }
+      }
+    ],
+    "additionalLinks": [
+      {
+        "pureId": 9477901,
+        "url": "http://www.scopus.com/inward/record.url?scp=0031523977&partnerID=8YFLogxK",
+        "description": {
+          "formatted": false,
+          "text": [
+            {
+              "locale": "en_US",
+              "value": "Link to publication in Scopus"
+            }
+          ]
+        },
+        "linkType": {
+          "pureId": 3436191,
+          "uri": "/dk/atira/pure/links/researchoutput/scopuspublication",
+          "term": {
+            "formatted": false,
+            "text": [
+              {
+                "locale": "en_US",
+                "value": "Scopus publication"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "pureId": 9477900,
+        "url": "http://www.scopus.com/inward/citedby.url?scp=0031523977&partnerID=8YFLogxK",
+        "description": {
+          "formatted": false,
+          "text": [
+            {
+              "locale": "en_US",
+              "value": "Link to citation list in Scopus"
+            }
+          ]
+        },
+        "linkType": {
+          "pureId": 3436193,
+          "uri": "/dk/atira/pure/links/researchoutput/scopuscitations",
+          "term": {
+            "formatted": false,
+            "text": [
+              {
+                "locale": "en_US",
+                "value": "Scopus citations"
+              }
+            ]
+          }
+        }
+      }
+    ],
+    "keywordGroups": [
+      {
+        "pureId": 34576019,
+        "logicalName": "ASJCSubjectAreas",
+        "type": {
+          "uri": "/dk/atira/pure/subjectarea/asjc",
+          "term": {
+            "formatted": false,
+            "text": [
+              {
+                "locale": "en_US",
+                "value": "All Science Journal Classification (ASJC) codes"
+              }
+            ]
+          }
+        },
+        "keywordContainers": [
+          {
+            "pureId": 34576020,
+            "structuredKeyword": {
+              "pureId": 6529,
+              "uri": "/dk/atira/pure/subjectarea/asjc/3200/3202",
+              "term": {
+                "formatted": false,
+                "text": [
+                  {
+                    "locale": "en_US",
+                    "value": "Applied Psychology"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "pureId": 34576021,
+            "structuredKeyword": {
+              "pureId": 6349,
+              "uri": "/dk/atira/pure/subjectarea/asjc/2700/2739",
+              "term": {
+                "formatted": false,
+                "text": [
+                  {
+                    "locale": "en_US",
+                    "value": "Public Health, Environmental and Occupational Health"
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "scopusMetrics": [
+      {
+        "value": 0,
+        "year": 2020
+      },
+      {
+        "value": 0,
+        "year": 2019
+      },
+      {
+        "value": 0,
+        "year": 2018
+      },
+      {
+        "value": 0,
+        "year": 2017
+      },
+      {
+        "value": 0,
+        "year": 2016
+      },
+      {
+        "value": 0,
+        "year": 2015
+      },
+      {
+        "value": 0,
+        "year": 2014
+      },
+      {
+        "value": 0,
+        "year": 2013
+      },
+      {
+        "value": 0,
+        "year": 2012
+      },
+      {
+        "value": 0,
+        "year": 2011
+      },
+      {
+        "value": 0,
+        "year": 2010
+      },
+      {
+        "value": 0,
+        "year": 2009
+      },
+      {
+        "value": 0,
+        "year": 2008
+      },
+      {
+        "value": 0,
+        "year": 2007
+      },
+      {
+        "value": 0,
+        "year": 2006
+      },
+      {
+        "value": 0,
+        "year": 2005
+      },
+      {
+        "value": 0,
+        "year": 2004
+      },
+      {
+        "value": 0,
+        "year": 2003
+      },
+      {
+        "value": 0,
+        "year": 2002
+      },
+      {
+        "value": 1,
+        "year": 2001
+      },
+      {
+        "value": 1,
+        "year": 2000
+      },
+      {
+        "value": 0,
+        "year": 1999
+      },
+      {
+        "value": 0,
+        "year": 1998
+      },
+      {
+        "value": 0,
+        "year": 1997
+      }
+    ]
+  },{
     "pureId": 9477909,
     "externalId": "84876918564",
     "externalIdSource": "Scopus",


### PR DESCRIPTION
changed ai and pure importers to check imported publication status and update existing pub status accordingly. fixes #465 
Updated a lot of existing tests with :count checks since new test publications were added to the ai xml and pure json