### PR TITLE
530 duplicate year

### DIFF
--- a/app/models/duplicate_publication_group.rb
+++ b/app/models/duplicate_publication_group.rb
@@ -19,12 +19,12 @@ class DuplicatePublicationGroup < ApplicationRecord
 
   def self.group_duplicates_of(publication)
     duplicates = if publication.imports.count == 1 && publication.imports.find { |i| i.source == 'Activity Insight' }
-                   Publication.where(%{similarity(CONCAT(title, secondary_title), ?) >= 0.6 AND (EXTRACT(YEAR FROM published_on) = ? OR published_on IS NULL)},
+                   Publication.where(%{similarity(CONCAT(title, secondary_title), ?) >= 0.6 AND (? BETWEEN EXTRACT(YEAR FROM published_on)-2 AND EXTRACT(YEAR FROM published_on)+2 OR published_on IS NULL)},
                                      "#{publication.title}#{publication.secondary_title}",
                                      publication.published_on.try(:year))
                      .where.not(id: publication.non_duplicate_groups.map { |g| g.memberships.map(&:publication_id) }.flatten).or(Publication.where(id: publication.id))
                  else
-                   Publication.where(%{similarity(CONCAT(title, secondary_title), ?) >= 0.6 AND (EXTRACT(YEAR FROM published_on) = ? OR published_on IS NULL) AND (doi = ? OR doi = '' OR doi IS NULL)},
+                   Publication.where(%{similarity(CONCAT(title, secondary_title), ?) >= 0.6 AND (? BETWEEN EXTRACT(YEAR FROM published_on)-2 AND EXTRACT(YEAR FROM published_on)+2 OR published_on IS NULL) AND (doi = ? OR doi = '' OR doi IS NULL)},
                                      "#{publication.title}#{publication.secondary_title}",
                                      publication.published_on.try(:year),
                                      publication.doi)

--- a/spec/component/models/duplicate_publication_group_spec.rb
+++ b/spec/component/models/duplicate_publication_group_spec.rb
@@ -526,8 +526,49 @@ describe DuplicatePublicationGroup, type: :model do
       it 'groups the publications' do
         described_class.group_duplicates_of(p1)
         group = p1.reload.duplicate_group
-
         expect(p2.reload.duplicate_group).to eq group
+      end
+    end
+
+    context 'given a publication with a similar title to another publication and a different publication date but the year is within +/-2' do
+      let!(:p1) { create :publication,
+                         title: 'A Typical Title',
+                         published_on: Date.new(2000, 5, 20),
+                         doi: nil }
+
+      let!(:p2) { create :publication,
+                         title: 'The Typical Title',
+                         published_on: Date.new(2002, 1, 1),
+                         doi: nil }
+      let!(:p3) { create :publication,
+                         title: 'The Typical Title 3',
+                         published_on: Date.new(2000, 5, 20),
+                         doi: nil }
+      it 'groups the publications' do
+        described_class.group_duplicates_of(p1)
+        group = p1.reload.duplicate_group
+        expect(p2.reload.duplicate_group).to eq group
+      end
+    end
+
+    context 'given a publication with a similar title to another publication and a different publication date but the year is more than +/-2' do
+      let!(:p1) { create :publication,
+                         title: 'A Typical Title',
+                         published_on: Date.new(2000, 5, 20),
+                         doi: nil }
+
+      let!(:p2) { create :publication,
+                         title: 'The Typical Title',
+                         published_on: Date.new(2003, 1, 1),
+                         doi: nil }
+      let!(:p3) { create :publication,
+                         title: 'The Typical Title 3',
+                         published_on: Date.new(2000, 5, 20),
+                         doi: nil }
+      it 'groups the publications' do
+        described_class.group_duplicates_of(p1)
+        group = p1.reload.duplicate_group
+        expect(p2.reload.duplicate_group).not_to eq group
       end
     end
 

--- a/spec/component/models/duplicate_publication_group_spec.rb
+++ b/spec/component/models/duplicate_publication_group_spec.rb
@@ -544,6 +544,7 @@ describe DuplicatePublicationGroup, type: :model do
                          title: 'The Typical Title 3',
                          published_on: Date.new(2000, 5, 20),
                          doi: nil }
+
       it 'groups the publications' do
         described_class.group_duplicates_of(p1)
         group = p1.reload.duplicate_group
@@ -565,6 +566,7 @@ describe DuplicatePublicationGroup, type: :model do
                          title: 'The Typical Title 3',
                          published_on: Date.new(2000, 5, 20),
                          doi: nil }
+
       it 'groups the publications' do
         described_class.group_duplicates_of(p1)
         group = p1.reload.duplicate_group

--- a/spec/component/models/duplicate_publication_group_spec.rb
+++ b/spec/component/models/duplicate_publication_group_spec.rb
@@ -540,14 +540,12 @@ describe DuplicatePublicationGroup, type: :model do
                          title: 'The Typical Title',
                          published_on: Date.new(2002, 1, 1),
                          doi: nil }
-      let!(:p3) { create :publication,
-                         title: 'The Typical Title 3',
-                         published_on: Date.new(2000, 5, 20),
-                         doi: nil }
 
       it 'groups the publications' do
         described_class.group_duplicates_of(p1)
         group = p1.reload.duplicate_group
+
+        expect(group).not_to be_nil
         expect(p2.reload.duplicate_group).to eq group
       end
     end


### PR DESCRIPTION
Changed logic in duplicate public grouping to allow the year to pass as long as it's within +/-2 years
fixes #530