### PR TITLE
blocked email notification if ai post print status is 'in progress'

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,6 +38,10 @@ RSpec/LeakyConstantDeclaration:
   Exclude:
     - 'spec/component/models/concerns/null_object_pattern_spec.rb'
 
+RSpec/MultipleMemoizedHelpers:
+   Exclude:
+     - 'spec/component/models/user_spec.rb'
+     
 Style/Semicolon:
   Exclude:
     - 'lib/tasks/database_data.rake'

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -127,6 +127,7 @@ class User < ApplicationRecord
       .where('publications.published_on >= user_organization_memberships.started_on AND (publications.published_on <= user_organization_memberships.ended_on OR user_organization_memberships.ended_on IS NULL)')
       .where('authorships.confirmed IS TRUE')
       .where('publications.visible = true')
+      .where('publications.activity_insight_postprint_status IS NULL OR publications.activity_insight_postprint_status != ?', 'In Progress')
       .where("open_access_locations.id IS NULL OR open_access_locations.url = ''")
       .distinct(:id)
   end

--- a/spec/component/models/user_spec.rb
+++ b/spec/component/models/user_spec.rb
@@ -426,7 +426,7 @@ describe User, type: :model do
                              user: email_user_1,
                              started_on: Date.new(2019, 1, 1),
                              ended_on: nil }
-    let!(:eu_pub_1) { create :publication, published_on: Date.new(2020, 7, 1) }
+    let!(:eu_pub_1) { create :publication, published_on: Date.new(2020, 7, 1), activity_insight_postprint_status: 'Cannot Deposit' }
     let!(:eu_auth_1) { create :authorship,
                               user: email_user_1,
                               publication: eu_pub_1,
@@ -437,7 +437,7 @@ describe User, type: :model do
                              user: email_user_2,
                              started_on: Date.new(2019, 1, 1),
                              ended_on: nil }
-    let!(:eu_pub_2) { create :publication, published_on: Date.new(2020, 7, 1) }
+    let!(:eu_pub_2) { create :publication, published_on: Date.new(2020, 7, 1), activity_insight_postprint_status: 'Cannot Deposit' }
     let!(:eu_auth_2) { create :authorship,
                               user: email_user_2,
                               publication: eu_pub_2,
@@ -448,7 +448,7 @@ describe User, type: :model do
                              user: email_user_3,
                              started_on: Date.new(2019, 1, 1),
                              ended_on: Date.new(2020, 7, 2) }
-    let!(:eu_pub_3) { create :publication, published_on: Date.new(2020, 7, 1) }
+    let!(:eu_pub_3) { create :publication, published_on: Date.new(2020, 7, 1), activity_insight_postprint_status: 'Cannot Deposit' }
     let!(:eu_auth_3) { create :authorship,
                               user: email_user_3,
                               publication: eu_pub_3,
@@ -461,7 +461,8 @@ describe User, type: :model do
                              ended_on: nil }
     let!(:eu_pub_4) { create :publication,
                              published_on: Date.new(2020, 7, 1),
-                             open_access_locations: [] }
+                             open_access_locations: [],
+                             activity_insight_postprint_status: nil }
     let!(:eu_auth_4) { create :authorship,
                               user: email_user_4,
                               publication: eu_pub_4,
@@ -660,6 +661,18 @@ describe User, type: :model do
     let!(:ou_auth_15) { create :authorship,
                                user: other_user_15,
                                publication: ou_pub_15,
+                               confirmed: true }
+
+    # filtered out due to the publication being in process of deposit to Scholarsphere via AI (activity_insight_postprint_status is 'In Progress')
+    let!(:other_user_18) { create :user, open_access_notification_sent_at: 1.year.ago, first_name: 'other_user_18' }
+    let!(:ou_mem_18) { create :user_organization_membership,
+                              user: other_user_18,
+                              started_on: Date.new(2019, 1, 1),
+                              ended_on: nil}
+    let!(:ou_pub_18) { create :publication, published_on: Date.new(2020, 7, 1), activity_insight_postprint_status: 'In Progress' }
+    let!(:ou_auth_18) { create :authorship,
+                               user: other_user_18,
+                               publication: ou_pub_18,
                                confirmed: true }
 
     it 'returns only users who should currently receive an email reminder about open access publications' do


### PR DESCRIPTION
Articles in process of deposit to ScholarSphere via AI should not get a nudge. If this is the case, activity_insight_postprint_status will be 'In Progress' and nudge is blocked.
fixes #113 