### PR TITLE
Automerge error handling

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -36,6 +36,7 @@ RSpec/AnyInstance:
     - 'spec/component/importers/activity_insight_importer_spec.rb'
     - 'spec/component/components/scholarsphere_deposit_form_component_spec.rb'
     - 'spec/integration/profiles/open_access_publications/edit_spec.rb'
+    - 'spec/component/models/duplicate_publication_group_spec.rb'
 
 RSpec/LeakyConstantDeclaration:
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -154,6 +154,7 @@ RSpec/MessageSpies:
     - 'spec/component/models/orcid_oauth_client_spec.rb'
     - 'spec/component/models/orcid_resource_spec.rb'
     - 'spec/component/services/scholarsphere_deposit_service_spec.rb'
+    - 'spec/component/models/duplicate_publication_group_spec.rb'
 
 # Offense count: 40
 RSpec/MultipleDescribes:

--- a/app/models/duplicate_publication_group.rb
+++ b/app/models/duplicate_publication_group.rb
@@ -98,6 +98,8 @@ class DuplicatePublicationGroup < ApplicationRecord
     else
       false
     end
+  rescue StandardError => e
+    Rails.logger.error e.message
   end
 
   def self.auto_merge_matching
@@ -147,6 +149,8 @@ class DuplicatePublicationGroup < ApplicationRecord
           destroy
         end
       end
+    rescue StandardError => e
+      Rails.logger.error e.message
     end
   end
 

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -705,11 +705,13 @@ class Publication < ApplicationRecord
         end
 
         update!(updated_by_user_at: Time.current, visible: true)
-      # TODO: We should catch more than just ActiveRecord::RecordNotSaved
-      # We should also log any errors caught to the ImporterErrorLog
-      rescue ActiveRecord::RecordNotSaved
-        nil
       end
+    # TODO: This is just a temporary solution to prevent errors from stopping the auto
+    # deduplication processes.  The returned error is rescued in the code for running
+    # those processes. The error will still be raised when manually deduping.
+    # Ideally, these errors should be logged somewhere like the ImporterErrorLog.
+    rescue StandardError => e
+      (raise e)
     end
 
     def preferred_journal_info_policy

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -705,6 +705,10 @@ class Publication < ApplicationRecord
         end
 
         update!(updated_by_user_at: Time.current, visible: true)
+      # TODO: We should catch more than just ActiveRecord::RecordNotSaved
+      # We should also log any errors caught to the ImporterErrorLog
+      rescue ActiveRecord::RecordNotSaved
+        nil
       end
     end
 

--- a/app/models/publication_merge_on_matching_policy.rb
+++ b/app/models/publication_merge_on_matching_policy.rb
@@ -123,11 +123,13 @@ class PublicationMergeOnMatchingPolicy
       if publication1.issn.blank? && publication2.issn.blank?
         nil
       else
-        [publication1.issn, publication2.issn]
+        issn_clean = [publication1.issn, publication2.issn]
           .compact_blank
           .min_by(&:length)
           .gsub(/[^0-9xX]/, '')[0..7]
-          .insert(4, '-')
+        if issn_clean.length > 5
+          issn_clean.insert(4, '-')
+        end
       end
     end
 

--- a/spec/component/models/duplicate_publication_group_spec.rb
+++ b/spec/component/models/duplicate_publication_group_spec.rb
@@ -1501,6 +1501,25 @@ describe DuplicatePublicationGroup, type: :model do
         end
       end
     end
+
+    context 'when an error is raised' do
+      let!(:pub1) { create :publication, title: 'A Generic Title', duplicate_group: group, imports: pub1_imports }
+      let!(:pub2) { create :publication, title: 'The Generic Title', duplicate_group: group, imports: pub2_imports }
+      let(:pub1_imports) { [ai_import] }
+      let(:pub2_imports) { [pure_import] }
+      let(:ai_import) { create(:publication_import, source: 'Activity Insight') }
+      let(:pure_import) { create(:publication_import, source: 'Pure') }
+
+      before do
+        allow_any_instance_of(Publication).to receive(:merge!).and_raise ActiveRecord::RecordNotSaved
+      end
+
+      it 'rescues error and logs error' do
+        expect(Rails.logger).to receive(:error).with('ActiveRecord::RecordNotSaved')
+        expect { group.auto_merge }.not_to change(Publication, :count)
+        expect { pub1.reload }.not_to raise_error ActiveRecord::RecordNotFound
+      end
+    end
   end
 
   describe '#auto_merge_matching' do
@@ -1633,6 +1652,27 @@ describe DuplicatePublicationGroup, type: :model do
         it 'does not delete the group' do
           expect { group.auto_merge_matching }.not_to change(described_class, :count)
         end
+      end
+    end
+
+    context 'when an error is raised' do
+      let!(:pub1) { create :sample_publication, duplicate_group: group }
+      let!(:pub2) do
+        Publication.create(pub1
+          .attributes
+          .delete_if { |key, _value| key == 'id' })
+      end
+      let!(:import1) { create :publication_import, publication: pub1 }
+      let!(:import2) { create :publication_import, publication: pub2 }
+
+      before do
+        allow_any_instance_of(Publication).to receive(:merge_on_matching!).and_raise ActiveRecord::RecordNotSaved
+      end
+
+      it 'rescues error and logs error' do
+        expect(Rails.logger).to receive(:error).with('ActiveRecord::RecordNotSaved').twice
+        expect { group.auto_merge_matching }.not_to change(Publication, :count)
+        expect { pub1.reload }.not_to raise_error ActiveRecord::RecordNotFound
       end
     end
   end


### PR DESCRIPTION
Rescuing StandardError during merge process for publications.  Passes the error along to the automerge processes to be rescued there and logged so the automerge process isn't stalled by errors.

closes #582