### PR TITLE
Handling integers and arrays in exif tool

### DIFF
--- a/app/models/scholarsphere_exif_file_version.rb
+++ b/app/models/scholarsphere_exif_file_version.rb
@@ -56,7 +56,13 @@ class ScholarsphereExifFileVersion
     def subject?
       subjects = ['downloaded from', 'journal pre-proof']
       subjects << @journal unless @journal.nil?
-      exif[:subject].present? and subjects.any? { |s| exif[:subject].downcase.include? s }
+      if exif[:subject].present? and exif[:subject].is_a?(Array)
+        subjects.any? { |s| exif[:subject]&.any? { |exs| exs.to_s.downcase.include? s } }
+      elsif exif[:subject].present? and exif[:subject].is_a?(String)
+        subjects.any? { |s| exif[:subject].downcase.include? s }
+      else
+        false
+      end
     end
 
     def rendition_class?
@@ -64,11 +70,11 @@ class ScholarsphereExifFileVersion
     end
 
     def creator?
-      !exif[:creator].nil? and PUBLISHED_VERSION_CREATORS.any? { |c| exif[:creator].downcase.include? c }
+      !exif[:creator].nil? and PUBLISHED_VERSION_CREATORS.any? { |c| exif[:creator].to_s.downcase.include? c }
     end
 
     def creator_tool?
-      !exif[:creator_tool].nil? and PUBLISHED_VERSION_CREATORS.any? { |ct| exif[:creator_tool].downcase.include? ct }
+      !exif[:creator_tool].nil? and PUBLISHED_VERSION_CREATORS.any? { |ct| exif[:creator_tool].to_s.downcase.include? ct }
     end
 
     def producer?

--- a/spec/component/models/scholarsphere_exif_file_version_spec.rb
+++ b/spec/component/models/scholarsphere_exif_file_version_spec.rb
@@ -29,6 +29,14 @@ describe ScholarsphereExifFileVersion do
         end
       end
 
+      context 'when creator field contains an integer' do
+        let(:exif_data) { { creator: 1 } }
+
+        it 'returns nil' do
+          expect(exif_file_version.version).to eq nil
+        end
+      end
+
       context 'when exif data validates both Accepted Manuscript and Final Publshed Version' do
         let(:exif_data) { { journal_article_version: 'am', subject: 'downloaded from' } }
 
@@ -99,6 +107,14 @@ describe ScholarsphereExifFileVersion do
 
         context 'when subject field is "journal pre-proof"' do
           let(:exif_data) { { subject: 'journal pre-proof' } }
+
+          it 'returns Final Published Version' do
+            expect(exif_file_version.version).to eq I18n.t('file_versions.published_version')
+          end
+        end
+
+        context 'when subject field is an Array that contains "journal pre-proof"' do
+          let(:exif_data) { { subject: ['other', 'journal pre-proof'] } }
 
           it 'returns Final Published Version' do
             expect(exif_file_version.version).to eq I18n.t('file_versions.published_version')

--- a/spec/component/models/scholarsphere_exif_file_version_spec.rb
+++ b/spec/component/models/scholarsphere_exif_file_version_spec.rb
@@ -37,6 +37,14 @@ describe ScholarsphereExifFileVersion do
         end
       end
 
+      context 'when creator_tool field contains an integer' do
+        let(:exif_data) { { creator_tool: 1 } }
+
+        it 'returns nil' do
+          expect(exif_file_version.version).to eq nil
+        end
+      end
+
       context 'when exif data validates both Accepted Manuscript and Final Publshed Version' do
         let(:exif_data) { { journal_article_version: 'am', subject: 'downloaded from' } }
 


### PR DESCRIPTION
Sometimes the subject fields from the exif tool can be an array, and the creator and creator_tool fields can have integers.  I modified some of the code to work with these types.  I also added some tests.