### PR TITLE
Allow OAL imports in Law importers for existing pubs

### DIFF
--- a/app/importers/oai_creator.rb
+++ b/app/importers/oai_creator.rb
@@ -14,7 +14,7 @@ class OAICreator
 
   def first_name
     fn = text.split(',')[1]
-    fn.strip.split.first.strip if fn
+    fn.strip.split.first.strip if fn.present?
   end
 
   def user_match

--- a/spec/component/importers/psu_dickinson_publication_importer_spec.rb
+++ b/spec/component/importers/psu_dickinson_publication_importer_spec.rb
@@ -16,7 +16,8 @@ describe PSUDickinsonPublicationImporter do
                     any_user_matches?: true,
                     identifier: 'existing-identifier',
                     publisher: 'Test Publisher',
-                    source: 'Test Source' }
+                    source: 'Test Source',
+                    url: 'https://example.com/article' }
   let(:r3) { double 'record 3',
                     any_user_matches?: true,
                     identifier: 'non-existing-identifier',
@@ -74,8 +75,8 @@ describe PSUDickinsonPublicationImporter do
       expect { importer.call }.to change(ContributorName, :count).by 2
     end
 
-    it "creates new open access locations for records that are importable and that don't already exist" do
-      expect { importer.call }.to change(OpenAccessLocation, :count).by 1
+    it 'creates new open access locations for records that are importable' do
+      expect { importer.call }.to change(OpenAccessLocation, :count).by 2
     end
 
     it 'is idempotent in terms of creating publication imports' do

--- a/spec/component/importers/psu_law_school_publication_importer_spec.rb
+++ b/spec/component/importers/psu_law_school_publication_importer_spec.rb
@@ -16,7 +16,8 @@ describe PSULawSchoolPublicationImporter do
                     any_user_matches?: true,
                     identifier: 'existing-identifier',
                     publisher: 'Test Publisher',
-                    source: 'Test Source' }
+                    source: 'Test Source',
+                    url: 'https://example.com/article' }
   let(:r3) { double 'record 3',
                     any_user_matches?: true,
                     identifier: 'non-existing-identifier',
@@ -74,8 +75,8 @@ describe PSULawSchoolPublicationImporter do
       expect { importer.call }.to change(ContributorName, :count).by 2
     end
 
-    it "creates new open access locations for records that are importable and that don't already exist" do
-      expect { importer.call }.to change(OpenAccessLocation, :count).by 1
+    it 'creates new open access locations for records that are importable' do
+      expect { importer.call }.to change(OpenAccessLocation, :count).by 2
     end
 
     it 'is idempotent in terms of creating publication imports' do


### PR DESCRIPTION
Moved OpenAccessLocation creation out of existing? block in the Law importers so they can be added to pre-existing publications.  Still idempotent though.  Fixed specs to test these changes.

closes #591 