### PR TITLE
Split OAB import

### DIFF
--- a/app/importers/open_access_button_publication_importer.rb
+++ b/app/importers/open_access_button_publication_importer.rb
@@ -41,7 +41,7 @@ class OpenAccessButtonPublicationImporter
     no_doi_pubs.find_each do |p|
       query_open_access_button_for(p)
       pbar.increment
-      sleep 1
+      sleep 1 unless Rails.env.test?
     end
     pbar.finish
   end

--- a/app/importers/open_access_button_publication_importer.rb
+++ b/app/importers/open_access_button_publication_importer.rb
@@ -23,6 +23,28 @@ class OpenAccessButtonPublicationImporter
     pbar.finish
   end
 
+  def import_with_doi
+    pbar = ProgressBarTTY.create(title: 'Importing publication data from Open Access Button',
+                                 total: doi_pubs.count)
+
+    doi_pubs.find_each do |p|
+      query_open_access_button_for(p)
+      pbar.increment
+    end
+    pbar.finish
+  end
+
+  def import_without_doi
+    pbar = ProgressBarTTY.create(title: 'Importing publication data from Open Access Button',
+                                 total: no_doi_pubs.count)
+
+    no_doi_pubs.find_each do |p|
+      query_open_access_button_for(p)
+      pbar.increment
+    end
+    pbar.finish
+  end
+
   private
 
     def all_pubs
@@ -31,6 +53,14 @@ class OpenAccessButtonPublicationImporter
 
     def new_pubs
       all_pubs.where(open_access_button_last_checked_at: nil)
+    end
+
+    def doi_pubs
+      all_pubs.where("doi IS NOT NULL AND doi <> ''")
+    end
+
+    def no_doi_pubs
+      all_pubs.where("doi IS NULL OR doi = ''")
     end
 
     def query_open_access_button_for(publication)

--- a/app/importers/open_access_button_publication_importer.rb
+++ b/app/importers/open_access_button_publication_importer.rb
@@ -41,6 +41,7 @@ class OpenAccessButtonPublicationImporter
     no_doi_pubs.find_each do |p|
       query_open_access_button_for(p)
       pbar.increment
+      sleep 1
     end
     pbar.finish
   end

--- a/lib/tasks/imports.rake
+++ b/lib/tasks/imports.rake
@@ -34,6 +34,16 @@ namespace :import do
     OpenAccessButtonPublicationImporter.new.import_new
   end
 
+  desc 'Import Open Access Button publication URLs for publications that have a DOI'
+  task with_doi_open_access_button: :environment do
+    OpenAccessButtonPublicationImporter.new.import_with_doi
+  end
+
+  desc 'Import Open Access Button publication URLs for publications that do not have a DOI'
+  task without_doi_open_access_button: :environment do
+    OpenAccessButtonPublicationImporter.new.import_without_doi
+  end
+
   desc 'Import Unpaywall publication metadata'
   task unpaywall: :environment do
     UnpaywallPublicationImporter.new.import_all


### PR DESCRIPTION
Split OAB import to have two new importers.  One that runs the OAB import on only pubs that have DOIs, and one that runs the OAB import on only pubs that don't have DOIs.  Tests and rake tasks.