### PR TITLE
makes upload queue configurable

### DIFF
--- a/app/jobs/scholarsphere_upload_job.rb
+++ b/app/jobs/scholarsphere_upload_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ScholarsphereUploadJob < ApplicationJob
-  queue_as "scholarsphere-uploads-#{`hostname`}".strip
+  queue_as Settings.delayed_job.upload_queue
 
   def perform(deposit_id, user_id)
     Scholarsphere::Client.reset

--- a/bin/background_jobs
+++ b/bin/background_jobs
@@ -3,7 +3,7 @@
 set -e
 
 number_of_workers=2
-queues="default,scholarsphere-uploads-$(hostname)"
+queues="default,scholarsphere-uploads"
 
 if [[ $# -eq 1 ]] ; then
     command=$1

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -19,6 +19,9 @@ datadog:
   enabled: false
   env: dev
 
+delayed_job:
+  upload_queue: scholarsphere-uploads
+
 orcid:
   client_id:
 

--- a/spec/component/jobs/scholarsphere_upload_job_spec.rb
+++ b/spec/component/jobs/scholarsphere_upload_job_spec.rb
@@ -6,7 +6,7 @@ describe ScholarsphereUploadJob, type: :job do
   describe '.perform_later' do
     ActiveJob::Base.queue_adapter = :test
     it 'enqueues a job' do
-      expect { described_class.perform_later(1, 2) }.to have_enqueued_job.with(1, 2).on_queue("scholarsphere-uploads-#{`hostname`}".strip)
+      expect { described_class.perform_later(1, 2) }.to have_enqueued_job.with(1, 2).on_queue(Settings.delayed_job.upload_queue)
     end
   end
 


### PR DESCRIPTION
Fixes #651 

We could have probably gotten away with hard-coding this, but if we ran into a situation where we were running on multiple linux nodes we might want to make each one unique. 