### PR TITLE
make action_mailer configurable

### DIFF
--- a/config/environments/beta.rb
+++ b/config/environments/beta.rb
@@ -68,11 +68,11 @@ Rails.application.configure do
   # config.active_job.queue_name_prefix = "researcher_metadata_beta"
 
   # Mail configuration
-  config.action_mailer.perform_deliveries = true
+  config.action_mailer.perform_deliveries = Settings.action_mailer.perform_deliveries
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.delivery_method = :smtp
-  config.action_mailer.smtp_settings = { address: 'smtp.psu.edu' }
-  config.action_mailer.default_url_options = { protocol: 'https', host: 'stage.metadata.libraries.psu.edu' }
+  config.action_mailer.smtp_settings = { address: Settings.action_mailer.smtp_server, port: Settings.action_mailer.smtp_port }
+  config.action_mailer.default_url_options = { protocol: Settings.action_mailer.default_url_options.protocol, host: Settings.action_mailer.default_url_options.host }
   config.action_mailer.perform_caching = false
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -68,11 +68,11 @@ Rails.application.configure do
   # config.active_job.queue_name_prefix = "researcher_metadata_production"
 
   # Mail configuration
-  config.action_mailer.perform_deliveries = true
+  config.action_mailer.perform_deliveries = Settings.action_mailer.perform_deliveries
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.delivery_method = :smtp
-  config.action_mailer.smtp_settings = { address: 'smtp.psu.edu' }
-  config.action_mailer.default_url_options = { protocol: 'https', host: 'metadata.libraries.psu.edu' }
+  config.action_mailer.smtp_settings = { address: Settings.action_mailer.smtp_server, port: Settings.action_mailer.smtp_port }
+  config.action_mailer.default_url_options = { protocol: Settings.action_mailer.default_url_options.protocol, host: Settings.action_mailer.default_url_options.host }
   config.action_mailer.perform_caching = false
 
   # Ignore bad email addresses and do not raise email delivery errors.

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -68,9 +68,10 @@ Rails.application.configure do
   # config.active_job.queue_name_prefix = "researcher_metadata_staging"
 
   config.action_mailer.perform_caching = false
-  config.action_mailer.perform_deliveries = false
-  config.action_mailer.default_url_options = { protocol: 'https', host: 'metadata-qa.libraries.psu.edu' }
-
+  config.action_mailer.perform_deliveries = Settings.action_mailer.perform_deliveries
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = { address: Settings.action_mailer.smtp_server, port: Settings.action_mailer.smtp_port }
+  config.action_mailer.default_url_options = { protocol: Settings.action_mailer.default_url_options.protocol, host: Settings.action_mailer.default_url_options.host }
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false

--- a/config/settings/beta.yml
+++ b/config/settings/beta.yml
@@ -3,5 +3,5 @@ action_mailer:
   smtp_server: smtp.psu.edu
   smtp_port: 25
   default_url_options:
-    host: metadata.libraries.psu.edu
+    host: stage.metadata.libraries.psu.edu
     protocol: https

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -1,7 +1,7 @@
 action_mailer:
-  perform_deliveries: true
+  perform_deliveries: false
   smtp_server: smtp.psu.edu
   smtp_port: 25
   default_url_options:
-    host: metadata.libraries.psu.edu
+    host: metadata-qa.libraries.psu.edu
     protocol: https


### PR DESCRIPTION
Fixes #655 

I could be convinced to promote all of the mail settings to `application.rb` and have the apps local configuration drive weather or not it's turned on. most of our other apps when deployed are 'production' even if they are 'preview' or 'qa' so, we might want to re-think how these are defaulted. this PR emulates the current behavior, and we can override in helm flipping the bits on and off. 