### PR TITLE
Use test doubles in place of PSU identity service API wrapper

### DIFF
--- a/spec/component/forms/new_deputy_assignment_form_spec.rb
+++ b/spec/component/forms/new_deputy_assignment_form_spec.rb
@@ -170,6 +170,11 @@ describe NewDeputyAssignmentForm, type: :model do
     context 'when a User exists for the given webaccess id' do
       let!(:existing_user) { create(:user, webaccess_id: deputy_webaccess_id, first_name: 'Deputy', last_name: 'FromDB') }
 
+      before do
+        person = instance_spy(PsuIdentity::SearchService::Person)
+        allow_any_instance_of(PsuIdentity::SearchService::Client).to receive(:userid).with(deputy_webaccess_id).and_return(person) # rubocop:todo RSpec/AnyInstance
+      end
+
       context 'when everything goes as expected' do
         it 'returns true' do
           expect(form.save).to be true
@@ -250,6 +255,11 @@ describe NewDeputyAssignmentForm, type: :model do
 
     context 'when you try to be your own deputy' do
       let(:deputy_webaccess_id) { primary.webaccess_id }
+
+      before do
+        person = instance_spy(PsuIdentity::SearchService::Person)
+        allow_any_instance_of(PsuIdentity::SearchService::Client).to receive(:userid).with(deputy_webaccess_id).and_return(person) # rubocop:todo RSpec/AnyInstance
+      end
 
       it 'returns false' do
         expect(form.save).to be false

--- a/spec/component/models/user_profile_spec.rb
+++ b/spec/component/models/user_profile_spec.rb
@@ -15,6 +15,12 @@ describe UserProfile do
                        ai_teaching_interests: 'test teaching interests',
                        ai_research_interests: 'test research interests') }
 
+  let(:piu_service) { class_double(PsuIdentityUserService).as_stubbed_const }
+
+  before do
+    allow(piu_service).to receive(:find_or_initialize_user)
+  end
+
   it { is_expected.to delegate_method(:active?).to(:user) }
   it { is_expected.to delegate_method(:available_deputy?).to(:user) }
   it { is_expected.to delegate_method(:id).to(:user) }
@@ -28,14 +34,12 @@ describe UserProfile do
   it { is_expected.to delegate_method(:total_scopus_citations).to(:user) }
 
   describe '::new' do
-    before { allow(PsuIdentityUserService).to receive(:find_or_initialize_user) }
-
     context 'when the user has data from the identity management service' do
       let(:user) { build(:user, :with_psu_identity) }
 
       it 'does NOT update their identity' do
         described_class.new(user)
-        expect(PsuIdentityUserService).not_to have_received(:find_or_initialize_user)
+        expect(piu_service).not_to have_received(:find_or_initialize_user)
       end
     end
 
@@ -44,7 +48,7 @@ describe UserProfile do
 
       it 'updates their identity' do
         described_class.new(user)
-        expect(PsuIdentityUserService).to have_received(:find_or_initialize_user)
+        expect(piu_service).to have_received(:find_or_initialize_user)
       end
     end
   end
@@ -58,10 +62,10 @@ describe UserProfile do
 
     context 'when ai_title is not present for user but multiple organization position_title from Pure are' do
       let!(:user_organization_membership1) do
-        create(:user_organization_membership, user: user, started_on: Date.yesterday, position_title: 'Title 1')
+        create(:user_organization_membership, user: user, started_on: 1.week.ago, position_title: 'Title 1')
       end
       let!(:user_organization_membership2) do
-        create(:user_organization_membership, user: user, started_on: Date.today, position_title: 'Title 2')
+        create(:user_organization_membership, user: user, started_on: 1.day.ago, position_title: 'Title 2')
       end
 
       before do

--- a/spec/component/models/user_spec.rb
+++ b/spec/component/models/user_spec.rb
@@ -295,7 +295,9 @@ describe User, type: :model do
 
       before do
         person = instance_spy(PsuIdentity::SearchService::Person)
-        allow_any_instance_of(PsuIdentity::SearchService::Client).to receive(:userid).with(user.webaccess_id).and_return(person) # rubocop:todo RSpec/AnyInstance
+        client = instance_double(PsuIdentity::SearchService::Client)
+        allow(PsuIdentity::SearchService::Client).to receive(:new).and_return(client)
+        allow(client).to receive(:userid).with(user.webaccess_id).and_return(person)
       end
 
       it 'returns the matching user' do

--- a/spec/component/models/user_spec.rb
+++ b/spec/component/models/user_spec.rb
@@ -293,6 +293,11 @@ describe User, type: :model do
       let(:user) { create(:user, webaccess_id: 'abc123') }
       let(:uid) { user.webaccess_id }
 
+      before do
+        person = instance_spy(PsuIdentity::SearchService::Person)
+        allow_any_instance_of(PsuIdentity::SearchService::Client).to receive(:userid).with(user.webaccess_id).and_return(person) # rubocop:todo RSpec/AnyInstance
+      end
+
       it 'returns the matching user' do
         expect(described_class.from_omniauth(auth)).to eq user
       end

--- a/spec/integration/profiles/claim_publication_spec.rb
+++ b/spec/integration/profiles/claim_publication_spec.rb
@@ -183,7 +183,7 @@ describe 'claiming authorship of a publication' do
 
           it 'sends a notification of the claim to the RMD admins' do
             open_email('rmd-admin@psu.edu')
-            expect(current_email.body).to match(/Test Claimer/)
+            expect(current_email.body).to match(/Test A Person/)
           end
 
           it 'returns the user to page for managing their profile publications' do

--- a/spec/integration/profiles/deputy_assignments/create_spec.rb
+++ b/spec/integration/profiles/deputy_assignments/create_spec.rb
@@ -21,6 +21,9 @@ describe 'Creating a new proxy', type: :feature do
 
     context 'when all goes well' do
       before do
+        person = instance_spy(PsuIdentity::SearchService::Person)
+        allow_any_instance_of(PsuIdentity::SearchService::Client).to receive(:userid).with('ajk5603').and_return(person) # rubocop:todo RSpec/AnyInstance
+
         fill_in 'new_deputy_assignment_form_deputy_webaccess_id', with: 'ajk5603'
         click_button I18n.t!('helpers.submit.new_deputy_assignment_form.create')
       end
@@ -40,6 +43,9 @@ describe 'Creating a new proxy', type: :feature do
 
     context 'when there is an error' do
       before do
+        person = instance_spy(PsuIdentity::SearchService::Person)
+        allow_any_instance_of(PsuIdentity::SearchService::Client).to receive(:userid).with('agw13').and_return(person) # rubocop:todo RSpec/AnyInstance
+
         existing_user = create(:user, webaccess_id: 'agw13')
         _existing_da = create(:deputy_assignment, :active, :confirmed, primary: user, deputy: existing_user)
       end

--- a/spec/integration/profiles/deputy_assignments/index_spec.rb
+++ b/spec/integration/profiles/deputy_assignments/index_spec.rb
@@ -52,6 +52,11 @@ describe 'Proxies page', type: :feature do
     end
 
     describe "when link is clicked in confirmed primary's name" do
+      before do
+        person = instance_spy(PsuIdentity::SearchService::Person)
+        allow_any_instance_of(PsuIdentity::SearchService::Client).to receive(:userid).with(primary_confirmed.webaccess_id).and_return(person) # rubocop:todo RSpec/AnyInstance
+      end
+
       it "directs user to primary's public profile page" do
         click_link primary_confirmed.name
         expect(page).to have_current_path profile_path(primary_confirmed.webaccess_id)

--- a/spec/integration/profiles/external_publication_waivers/create_spec.rb
+++ b/spec/integration/profiles/external_publication_waivers/create_spec.rb
@@ -49,7 +49,7 @@ describe 'submitting an open access waiver for a publication that is not in the 
         open_email('test123@psu.edu')
         expect(current_email).not_to be_nil
         expect(current_email.subject).to match(/PSU Open Access Policy Waiver for Requested Article/i)
-        expect(current_email.body).to match(/Test User/)
+        expect(current_email.body).to match(/Test A Person/)
         expect(current_email.body).to match(/My Test Publication/)
         expect(current_email.body).to match(/Test Journal/)
       end
@@ -81,6 +81,10 @@ describe 'submitting an open access waiver for a publication that is not in the 
     let(:deputy) { create(:user) }
 
     before do
+      person = instance_spy(PsuIdentity::SearchService::Person)
+      allow_any_instance_of(PsuIdentity::SearchService::Client).to receive(:userid).with(user.webaccess_id).and_return(person) # rubocop:todo RSpec/AnyInstance
+      allow(person).to receive(:as_json).and_return({ 'data' => {} })
+
       create(:deputy_assignment, primary: user, deputy: deputy)
       impersonate_user(primary: user, deputy: deputy)
       visit new_external_publication_waiver_path

--- a/spec/integration/profiles/internal_publication_waivers/new_spec.rb
+++ b/spec/integration/profiles/internal_publication_waivers/new_spec.rb
@@ -83,7 +83,7 @@ describe 'visiting the page to submit an open access waiver for a publication' d
           open_email('test123@psu.edu')
           expect(current_email).not_to be_nil
           expect(current_email.subject).to match(/PSU Open Access Policy Waiver for Requested Article/i)
-          expect(current_email.body).to match(/Test User/)
+          expect(current_email.body).to match(/Test A Person/)
           expect(current_email.body).to match(/Test Publication/)
           expect(current_email.body).to match(/A Prestegious Journal/)
         end

--- a/spec/integration/profiles/open_access_publications/edit_spec.rb
+++ b/spec/integration/profiles/open_access_publications/edit_spec.rb
@@ -287,7 +287,7 @@ describe 'visiting the page to edit the open acess status of a publication', typ
 
           it 'notifies the user by email that the deposit was successful' do
             open_email('xyz123@psu.edu')
-            expect(current_email.body).to match(/Robert Author/)
+            expect(current_email.body).to match(/Test A Person/)
             expect(current_email.body).to match(/Test Publication/)
             expect(current_email.body).to match(/https:\/\/scholarsphere\.test\/the-url/)
           end
@@ -361,7 +361,7 @@ describe 'visiting the page to edit the open acess status of a publication', typ
 
         it 'notifies the user by email that the deposit failed' do
           open_email('xyz123@psu.edu')
-          expect(current_email.body).to match(/Robert Author/)
+          expect(current_email.body).to match(/Test A Person/)
           expect(current_email.body).to match(/Test Publication/)
           expect(current_email.body).to match(/issue uploading/)
         end

--- a/spec/integration/user_profile_spec.rb
+++ b/spec/integration/user_profile_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+# One brittle test to verify our interaction with the real PSU identity web service
+require 'component/component_spec_helper'
+
+describe UserProfile do
+  subject(:profile) { described_class.new(user) }
+
+  describe '::new' do
+    context 'when the user has data from the identity management service' do
+      let(:user) { 
+        create(
+          :user, 
+          :with_psu_identity,
+          webaccess_id: 'dmc186',
+          first_name: 'Test',
+          last_name: 'User'
+        )
+      }
+
+      it 'does NOT update their identity' do
+        described_class.new(user)
+        u = user.reload
+        expect(u.first_name).to eq 'Test'
+        expect(u.middle_name).to be_nil
+        expect(u.last_name).to eq 'User'
+        expect(u.psu_identity.data).to eq({"affiliation" => ["FACULTY"], "familyName" => "User", "givenName" => "Test", "userid" => "dmc186"})
+      end
+    end
+
+    context 'when the user has not updated their identity data' do
+      let(:user) { 
+        create(
+          :user,
+          webaccess_id: 'dmc186',
+          first_name: 'Test',
+          last_name: 'User'
+        )
+      }
+
+      it 'updates their identity' do
+        described_class.new(user)
+        u = user.reload
+        expect(u.first_name).to eq 'Daniel'
+        expect(u.middle_name).to eq 'M'
+        expect(u.last_name).to eq 'Coughlin'
+        expect(u.psu_identity.data["givenName"]).to eq 'Daniel'
+        expect(u.psu_identity.data["middleName"]).to eq 'M'
+        expect(u.psu_identity.data["familyName"]).to eq 'Coughlin'
+        expect(u.psu_identity.data["affiliation"]).to eq ['FACULTY']
+        expect(u.psu_identity.data["userid"]).to eq 'dmc186'
+        expect(u.psu_identity_updated_at).not_to be_nil
+      end
+    end
+  end
+end

--- a/spec/integration/user_profile_spec.rb
+++ b/spec/integration/user_profile_spec.rb
@@ -8,9 +8,9 @@ describe UserProfile do
 
   describe '::new' do
     context 'when the user has data from the identity management service' do
-      let(:user) { 
+      let(:user) {
         create(
-          :user, 
+          :user,
           :with_psu_identity,
           webaccess_id: 'dmc186',
           first_name: 'Test',
@@ -24,12 +24,12 @@ describe UserProfile do
         expect(u.first_name).to eq 'Test'
         expect(u.middle_name).to be_nil
         expect(u.last_name).to eq 'User'
-        expect(u.psu_identity.data).to eq({"affiliation" => ["FACULTY"], "familyName" => "User", "givenName" => "Test", "userid" => "dmc186"})
+        expect(u.psu_identity.data).to eq({ 'affiliation' => ['FACULTY'], 'familyName' => 'User', 'givenName' => 'Test', 'userid' => 'dmc186' })
       end
     end
 
     context 'when the user has not updated their identity data' do
-      let(:user) { 
+      let(:user) {
         create(
           :user,
           webaccess_id: 'dmc186',
@@ -44,11 +44,11 @@ describe UserProfile do
         expect(u.first_name).to eq 'Daniel'
         expect(u.middle_name).to eq 'M'
         expect(u.last_name).to eq 'Coughlin'
-        expect(u.psu_identity.data["givenName"]).to eq 'Daniel'
-        expect(u.psu_identity.data["middleName"]).to eq 'M'
-        expect(u.psu_identity.data["familyName"]).to eq 'Coughlin'
-        expect(u.psu_identity.data["affiliation"]).to eq ['FACULTY']
-        expect(u.psu_identity.data["userid"]).to eq 'dmc186'
+        expect(u.psu_identity.data['givenName']).to eq 'Daniel'
+        expect(u.psu_identity.data['middleName']).to eq 'M'
+        expect(u.psu_identity.data['familyName']).to eq 'Coughlin'
+        expect(u.psu_identity.data['affiliation']).to eq ['FACULTY']
+        expect(u.psu_identity.data['userid']).to eq 'dmc186'
         expect(u.psu_identity_updated_at).not_to be_nil
       end
     end

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -691,6 +691,14 @@ describe API::V1::UsersController do
 
     context 'for a valid webaccess_id' do
       before do
+        person = instance_spy(PsuIdentity::SearchService::Person)
+        allow_any_instance_of(PsuIdentity::SearchService::Client).to receive(:userid).with(webaccess_id).and_return(person) # rubocop:todo RSpec/AnyInstance
+        allow(person).to receive(:as_json).and_return({ 'data' => {} })
+        allow(person).to receive(:preferred_given_name).and_return('Bob')
+        allow(person).to receive(:preferred_middle_name).and_return('')
+        allow(person).to receive(:middle_name).and_return('')
+        allow(person).to receive(:preferred_family_name).and_return('Testerson')
+
         get "/v1/users/#{webaccess_id}/profile", headers: headers
       end
 

--- a/spec/support/authentication.rb
+++ b/spec/support/authentication.rb
@@ -5,11 +5,20 @@ module StubbedAuthenticationHelper
   # (pass in the entire user object, not just a username).
 
   def sign_in_as(user)
+    person = instance_double(PsuIdentity::SearchService::Person)
+    allow_any_instance_of(PsuIdentity::SearchService::Client).to receive(:userid).with(user.webaccess_id).and_return(person) # rubocop:todo RSpec/AnyInstance
+    allow(person).to receive(:preferred_given_name).and_return('Test')
+    allow(person).to receive(:preferred_middle_name).and_return('A')
+    allow(person).to receive(:preferred_family_name).and_return('Person')
+    allow(person).to receive(:as_json).and_return({ 'data' => {} })
+
     OmniAuth.config.test_mode = true
-    OmniAuth.config.mock_auth[:azure_oauth] = OmniAuth::AuthHash.new({
-                                                                       provider: 'azure_oauth',
-                                                                       uid: user.webaccess_id
-                                                                     })
+    OmniAuth.config.mock_auth[:azure_oauth] = OmniAuth::AuthHash.new(
+      {
+        provider: 'azure_oauth',
+        uid: user.webaccess_id
+      }
+    )
   end
 end
 


### PR DESCRIPTION
So this currently does the mocking part of what I was suggesting in https://github.com/psu-libraries/researcher-metadata/pull/647. I noticed that the tests for our wrapper for the psu_identity gem are using VCR cassettes to mock the HTTP responses already. So now I don't think that we have any tests that are checking our interaction with the real identity service API, and with that being the case, I still think we should write one that does. I'll try to do that if I get a chance.