### PR TITLE
ActivityInsightOaFile Importer

### DIFF
--- a/app/importers/activity_insight_importer.rb
+++ b/app/importers/activity_insight_importer.rb
@@ -201,7 +201,8 @@ class ActivityInsightImporter
             end
           end
 
-          activity_insight_file_location = pub.postprints.first.location
+          activity_insight_file_location = pub.postprints&.first&.location
+
           if pub_record.no_open_access_information? && activity_insight_file_location.present?
             aif = pub_record.activity_insight_oa_files.first
 

--- a/app/importers/activity_insight_importer.rb
+++ b/app/importers/activity_insight_importer.rb
@@ -200,6 +200,20 @@ class ActivityInsightImporter
               c.save!
             end
           end
+
+          activity_insight_file_location = pub.postprints.first.location
+          if pub_record.no_open_access_information? && activity_insight_file_location.present?
+            aif = pub_record.activity_insight_oa_files.first
+
+            if aif.present?
+              aif.update location: activity_insight_file_location
+              aif.save!
+            else
+              file = ActivityInsightOaFile.create(location: activity_insight_file_location)
+              pub_record.activity_insight_oa_files << file
+              pub_record.save!
+            end
+          end
         end
       rescue StandardError => e
         log_error(pub, e, u)
@@ -960,6 +974,10 @@ class ActivityInsightPublicationPostprint
     # NOTE: this field is misspelled as "ACCESIBLE" (one S) on the Activity Insight side,
     # so the below misspelling is intentional.
     text_for('ACCESIBLE')
+  end
+
+  def location
+    text_for('DOC')
   end
 
   private

--- a/db/migrate/20230117202454_remove_checksum_from_activity_insight_oa_file.rb
+++ b/db/migrate/20230117202454_remove_checksum_from_activity_insight_oa_file.rb
@@ -1,0 +1,9 @@
+class RemoveChecksumFromActivityInsightOaFile < ActiveRecord::Migration[6.1]
+  def up
+    remove_column :activity_insight_oa_files, :checksum, :string
+  end
+
+  def down
+    add_column :activity_insight_oa_files, :checksum, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_01_10_174055) do
+ActiveRecord::Schema.define(version: 2023_01_17_202454) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -46,7 +46,6 @@ ActiveRecord::Schema.define(version: 2023_01_10_174055) do
 
   create_table "activity_insight_oa_files", force: :cascade do |t|
     t.string "location"
-    t.string "checksum"
     t.bigint "publication_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/spec/component/importers/activity_insight_importer_spec.rb
+++ b/spec/component/importers/activity_insight_importer_spec.rb
@@ -4936,6 +4936,7 @@ describe ActivityInsightImporter do
           p3 = PublicationImport.find_by(source: 'Activity Insight',
                                          source_identifier: '190707482930').publication
 
+          expect(ActivityInsightOaFile.count).to be 3
           expect(p1.activity_insight_oa_files.first.location).to eq('abc123/intellcont/file.pdf')
           expect(p2.activity_insight_oa_files.first.location).to eq('abc123/intellcont/file-3.pdf')
           expect(p3.activity_insight_oa_files.first.location).to eq('abc123/intellcont/file-5.pdf')

--- a/spec/component/models/activity_insight_oa_file_spec.rb
+++ b/spec/component/models/activity_insight_oa_file_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe ActivityInsightOaFile, type: :model do
   subject { described_class.new }
 
   it { is_expected.to have_db_column(:location).of_type(:string) }
-  it { is_expected.to have_db_column(:checksum).of_type(:string) }
   it { is_expected.to have_db_column(:created_at).of_type(:datetime).with_options(null: false) }
   it { is_expected.to have_db_column(:updated_at).of_type(:datetime).with_options(null: false) }
 

--- a/spec/factories/activity_insight_oa_file.rb
+++ b/spec/factories/activity_insight_oa_file.rb
@@ -4,6 +4,5 @@ FactoryBot.define do
   factory :activity_insight_oa_file do
     publication
     location { 'abc123/intellcont/test_file.pdf' }
-    checksum { SecureRandom.hex(64) }
   end
 end

--- a/spec/fixtures/activity_insight_user_abc123.xml
+++ b/spec/fixtures/activity_insight_user_abc123.xml
@@ -487,7 +487,7 @@
         <FULL_TEXT/>
       </INTELLCONT_FILE>
       <POST_FILE id="171620739080">
-        <DOC/>
+        <DOC>abc123/intellcont/file.pdf</DOC>
         <ACCESIBLE>In Progress</ACCESIBLE>
       </POST_FILE>
       <DTM_EXPSUB/>
@@ -738,7 +738,7 @@
       <DESC_INTERNATIONAL/>
       <RESEARCH_PROJECT/>
       <POST_FILE id="171620739081">
-        <DOC/>
+        <DOC>abc123/intellcont/file-3.pdf</DOC>
         <ACCESIBLE>Deposited to ScholarSphere</ACCESIBLE>
       </POST_FILE>
       <POST_FILE id="171620739082">
@@ -902,7 +902,7 @@
       <DESC_INTERNATIONAL/>
       <RESEARCH_PROJECT/>
       <POST_FILE id="271620739081">
-        <DOC/>
+        <DOC>abc123/intellcont/file-5.pdf</DOC>
         <ACCESIBLE>In Progress</ACCESIBLE>
       </POST_FILE>
       <DTM_EXPSUB/>


### PR DESCRIPTION
The importer will import an `ActivityInsightOaFile` if there is a 'POST_FILE' with a 'DOC' (location) for a publication in Activity Insight.  It will not import a file if a publication is already open access in RMD.  This PR also removes the checksum field for `ActivityInsightOaFile` since it isn't needed.

I added the tests for this importer to the end of spec/component/importers/activity_insight_importer_spec.rb.  This file is getting so large, it's hard to know where to put things.  It may be due for a refactoring (along with the importer).  I think it covers everything it needs to, though.

closes #635 