### PR TITLE
Merge Activity Insight files during publication merge

### DIFF
--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -696,6 +696,8 @@ class Publication < ApplicationRecord
         oalmp = OpenAccessLocationMergePolicy.new(all_pubs)
         self.open_access_locations = oalmp.open_access_locations_to_keep
 
+        self.activity_insight_oa_files = all_pubs.map(&:activity_insight_oa_files).flatten
+
         yield if block_given?
 
         pubs_to_delete.each do |p|

--- a/spec/component/models/publication_spec.rb
+++ b/spec/component/models/publication_spec.rb
@@ -1310,6 +1310,9 @@ describe Publication, type: :model do
 
     let(:visibility) { false }
 
+    let!(:activity_insight_oa_file1) { create(:activity_insight_oa_file, publication: pub1) }
+    let!(:activity_insight_oa_file2) { create(:activity_insight_oa_file, publication: pub2) }
+
     before do
       create(:authorship,
              publication: pub1,
@@ -1550,6 +1553,15 @@ describe Publication, type: :model do
       end
     end
 
+    it 'transfers all activity insight oa files from publications to the publication' do
+      expect(pub1.activity_insight_oa_files.count).to eq 1
+      pub1.merge!([pub2, pub3, pub4])
+
+      expect(pub1.reload.activity_insight_oa_files.count).to eq 2
+      expect(pub1.reload.activity_insight_oa_files).to match_array [activity_insight_oa_file1,
+                                                                    activity_insight_oa_file2]
+    end
+
     context 'when the given publications include the publication' do
       it 'reassigns all of the imports from the given publications to the publication' do
         pub1.merge!([pub1, pub2, pub3, pub4])
@@ -1558,6 +1570,15 @@ describe Publication, type: :model do
                                                     pub2_import1,
                                                     pub2_import2,
                                                     pub3_import1]
+      end
+
+      it 'transfers all activity insight oa files from publications to the publication' do
+        expect(pub1.activity_insight_oa_files.count).to eq 1
+        pub1.merge!([pub2, pub3, pub4])
+
+        expect(pub1.reload.activity_insight_oa_files.count).to eq 2
+        expect(pub1.reload.activity_insight_oa_files).to match_array [activity_insight_oa_file1,
+                                                                      activity_insight_oa_file2]
       end
 
       it 'deletes the given publications except for the publication' do
@@ -1732,6 +1753,13 @@ describe Publication, type: :model do
           rescue RuntimeError; end
           expect(pub1.reload.visible).to be true
         end
+      end
+
+      it 'does not transfer activity insight oa files' do
+        begin
+          pub1.merge!([pub2, pub3, pub4])
+        rescue RuntimeError; end
+        expect(pub1.reload.activity_insight_oa_files.count).to eq 1
       end
     end
 
@@ -1908,6 +1936,15 @@ describe Publication, type: :model do
 
           expect(pub1.reload.visible).to be true
         end
+      end
+
+      it 'transfers all activity insight oa files from publications to the publication' do
+        expect(pub1.activity_insight_oa_files.count).to eq 1
+        pub1.merge!([pub2, pub3, pub4])
+
+        expect(pub1.reload.activity_insight_oa_files.count).to eq 2
+        expect(pub1.reload.activity_insight_oa_files).to match_array [activity_insight_oa_file1,
+                                                                      activity_insight_oa_file2]
       end
     end
 
@@ -2087,6 +2124,15 @@ describe Publication, type: :model do
           expect(pub1.reload.visible).to be true
         end
       end
+
+      it 'transfers all activity insight oa files from publications to the publication' do
+        expect(pub1.activity_insight_oa_files.count).to eq 1
+        pub1.merge!([pub2, pub3, pub4])
+
+        expect(pub1.reload.activity_insight_oa_files.count).to eq 2
+        expect(pub1.reload.activity_insight_oa_files).to match_array [activity_insight_oa_file1,
+                                                                      activity_insight_oa_file2]
+      end
     end
 
     context 'when two of the given publications are in the same non-duplicate group' do
@@ -2239,6 +2285,13 @@ describe Publication, type: :model do
           rescue Publication::NonDuplicateMerge; end
           expect(pub1.reload.visible).to be true
         end
+      end
+
+      it 'does not transfer activity insight oa files' do
+        begin
+          pub1.merge!([pub2, pub3, pub4])
+        rescue Publication::NonDuplicateMerge; end
+        expect(pub1.reload.activity_insight_oa_files.count).to eq 1
       end
     end
 
@@ -2395,6 +2448,13 @@ describe Publication, type: :model do
           expect(pub1.reload.visible).to be true
         end
       end
+
+      it 'does not transfer activity insight oa files' do
+        begin
+          pub1.merge!([pub2, pub3, pub4])
+        rescue Publication::NonDuplicateMerge; end
+        expect(pub1.reload.activity_insight_oa_files.count).to eq 1
+      end
     end
 
     context 'when one of the given publications is in the same non-duplicate group as the publication' do
@@ -2548,6 +2608,13 @@ describe Publication, type: :model do
           expect(pub1.reload.visible).to be true
         end
       end
+
+      it 'does not transfer activity insight oa files' do
+        begin
+          pub1.merge!([pub2, pub3, pub4])
+        rescue Publication::NonDuplicateMerge; end
+        expect(pub1.reload.activity_insight_oa_files.count).to eq 1
+      end
     end
 
     context 'when all of the publications are in the same non-duplicate group' do
@@ -2700,6 +2767,13 @@ describe Publication, type: :model do
           rescue Publication::NonDuplicateMerge; end
           expect(pub1.reload.visible).to be true
         end
+      end
+
+      it 'does not transfer activity insight oa files' do
+        begin
+          pub1.merge!([pub2, pub3, pub4])
+        rescue Publication::NonDuplicateMerge; end
+        expect(pub1.reload.activity_insight_oa_files.count).to eq 1
       end
     end
   end


### PR DESCRIPTION
Link all `ActivityInsightOaFiles` to the merge point publication when merging publications.  We'll need to build something into the workflow where admins (or potentially some automation) can determine which of these files will be the preferred one before it can be exported the ScholarSphere.

closes #636