### PR TITLE
Adds Activity Insight Oa Workflow controller.  

### DIFF
--- a/app/controllers/activity_insight_oa_workflow_controller.rb
+++ b/app/controllers/activity_insight_oa_workflow_controller.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class ActivityInsightOaWorkflowController < ApplicationController
+  before_action :authenticate!
+  before_action :require_admin
+
+  def index
+  end
+
+  private
+
+    def authenticate!
+      session[:requested_url] = request.url
+      authenticate_user!
+    end
+
+    def require_admin
+      unless current_user.admin?
+        redirect_to root_path, alert: I18n.t('admin.authorization.not_authorized') 
+      end
+    end
+end

--- a/app/controllers/activity_insight_oa_workflow_controller.rb
+++ b/app/controllers/activity_insight_oa_workflow_controller.rb
@@ -4,8 +4,7 @@ class ActivityInsightOaWorkflowController < ApplicationController
   before_action :authenticate!
   before_action :require_admin
 
-  def index
-  end
+  def index; end
 
   private
 
@@ -16,7 +15,7 @@ class ActivityInsightOaWorkflowController < ApplicationController
 
     def require_admin
       unless current_user.admin?
-        redirect_to root_path, alert: I18n.t('admin.authorization.not_authorized') 
+        redirect_to root_path, alert: I18n.t('admin.authorization.not_authorized')
       end
     end
 end

--- a/app/views/activity_insight_oa_workflow/index.html.erb
+++ b/app/views/activity_insight_oa_workflow/index.html.erb
@@ -2,7 +2,7 @@
   <div class="row">
     <div class='col-xl'>
       <h1>Activity Insight Open Access Workflow</h1>
-      <hr/>
+      <hr>
     </div>
   </div>
 </div>

--- a/app/views/activity_insight_oa_workflow/index.html.erb
+++ b/app/views/activity_insight_oa_workflow/index.html.erb
@@ -1,0 +1,8 @@
+<div class="container">
+  <div class="row">
+    <div class='col-xl'>
+      <h1>Activity Insight Open Access Workflow</h1>
+      <hr/>
+    </div>
+  </div>
+</div>

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -125,4 +125,10 @@ RailsAdmin.config do |config|
   end
 
   config.compact_show_view = false
+
+  # Non-rails-admin links
+  config.navigation_static_label = "Workflows"
+  config.navigation_static_links = {
+    'Activity Insight Open Access Workflow' => '/activity_insight_oa_workflow'
+  }
 end

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -127,7 +127,7 @@ RailsAdmin.config do |config|
   config.compact_show_view = false
 
   # Non-rails-admin links
-  config.navigation_static_label = "Workflows"
+  config.navigation_static_label = 'Workflows'
   config.navigation_static_links = {
     'Activity Insight Open Access Workflow' => '/activity_insight_oa_workflow'
   }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,7 @@ Rails.application.routes.draw do
     end
   end
 
-  get '/activity_insight_oa_workflow' => 'activity_insight_oa_workflow#index' 
+  get '/activity_insight_oa_workflow' => 'activity_insight_oa_workflow#index'
 
   root to: 'public#home'
   get '/resources' => 'public#resources', as: :resources

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,8 @@ Rails.application.routes.draw do
     end
   end
 
+  get '/activity_insight_oa_workflow' => 'activity_insight_oa_workflow#index' 
+
   root to: 'public#home'
   get '/resources' => 'public#resources', as: :resources
   get '/api_docs' => 'public#api_docs', as: :api_docs

--- a/spec/component/controllers/activity_insight_oa_workflow_controller_spec.rb
+++ b/spec/component/controllers/activity_insight_oa_workflow_controller_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'component/component_spec_helper'
+require 'component/controllers/shared_examples_for_an_unauthenticated_controller'
+
+describe ActivityInsightOaWorkflowController, type: :controller do
+  let!(:user) { create(:user, is_admin: false) }
+
+  describe '#index' do
+    let(:perform_request) { get :index }
+
+    it_behaves_like 'an unauthenticated controller'
+
+    context 'when the user is not an admin' do
+      before do
+        allow(request.env['warden']).to receive(:authenticate!).and_return(user)
+        allow(controller).to receive(:current_user).and_return(user)
+      end
+
+      it 'redirects to the home page and sets flash message' do
+        expect(perform_request).to redirect_to root_path
+        expect(flash[:alert]).to eq I18n.t('admin.authorization.not_authorized')
+      end
+    end
+
+    context 'when the user is an admin' do
+      before do
+        user.update is_admin: true
+        allow(request.env['warden']).to receive(:authenticate!).and_return(user)
+        allow(controller).to receive(:current_user).and_return(user)
+      end
+
+      it 'renders the Activity Insight Open Access Workflow page' do
+        expect(perform_request).to render_template(:index)
+      end
+    end
+  end
+end

--- a/spec/integration/admin/activity_insight_oa_workflow/dashboard_spec.rb
+++ b/spec/integration/admin/activity_insight_oa_workflow/dashboard_spec.rb
@@ -17,7 +17,7 @@ describe 'Admin Activity Insight Oa Workflow dashboard', type: :feature do
     end
   end
 
-  context 'when the current user is an admin' do
+  context 'when the current user is not an admin' do
     before do
       authenticate_user
       visit activity_insight_oa_workflow_path

--- a/spec/integration/admin/activity_insight_oa_workflow/dashboard_spec.rb
+++ b/spec/integration/admin/activity_insight_oa_workflow/dashboard_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'integration/integration_spec_helper'
+
+describe 'Admin Activity Insight Oa Workflow dashboard', type: :feature do
+  context 'when the current user is an admin' do
+    before do
+      authenticate_admin_user
+      visit activity_insight_oa_workflow_path
+    end
+
+    describe 'accessing the page' do
+      it 'loads the page' do
+        expect(page).to have_current_path activity_insight_oa_workflow_path
+        expect(page).to have_content 'Activity Insight Open Access Workflow'
+      end
+    end
+  end
+
+  context 'when the current user is an admin' do
+    before do
+      authenticate_user
+      visit activity_insight_oa_workflow_path
+    end
+
+    describe 'accessing the page' do
+      it 'redirects to home page' do
+        expect(page).to have_current_path root_path
+      end
+    end
+  end
+end

--- a/spec/integration/admin/shared_examples_for_admin_page.rb
+++ b/spec/integration/admin/shared_examples_for_admin_page.rb
@@ -108,4 +108,8 @@ shared_examples_for 'a page with the admin layout' do
   it 'shows a logout link' do
     expect(page).to have_link 'Log out', href: destroy_user_session_path
   end
+
+  it 'shows a link to the Activity Insight Open Access Workflows page' do
+    expect(page).to have_link 'Activity Insight Open Access Workflow'
+  end
 end


### PR DESCRIPTION
For now it is just set up with basic authentication and admin authorization.  I had hoped I could put this behind `/admin`. However, anything behind `/admin` is caught by `RailsAdmin` where it begins looking for a model (and subsequently breaks).

Also, I added a link to this from the Rails Admin dashboard.  Controller tests for authentication/authorization as well as a test in the integration specs for the link.

closes #627