### PR TITLE
Sort duplicate publication groups from lowest to highest id

### DIFF
--- a/app/models/duplicate_publication_group.rb
+++ b/app/models/duplicate_publication_group.rb
@@ -167,7 +167,7 @@ class DuplicatePublicationGroup < ApplicationRecord
     end
 
     list do
-      field(:id)
+      field(:id) { sort_reverse false }
       field(:first_publication_title) { label 'Title of first duplicate' }
       field(:publication_count) { label 'Number of duplicates' }
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -480,7 +480,6 @@ ActiveRecord::Schema.define(version: 2023_02_02_152224) do
     t.string "activity_insight_postprint_status"
     t.boolean "doi_verified"
     t.string "oa_workflow_state"
-
     t.index "date_part('year'::text, published_on)", name: "index_publications_on_published_on_year"
     t.index ["doi"], name: "index_publications_on_doi"
     t.index ["duplicate_publication_group_id"], name: "index_publications_on_duplicate_publication_group_id"


### PR DESCRIPTION
Don't reverse sort duplicate publication groups so that the oldest are first in the list.  Also, running db migrations removed a space in the schema so there's that too.