### PR TITLE
Record failure to find missing DOI

### DIFF
--- a/app/jobs/doi_verification_job.rb
+++ b/app/jobs/doi_verification_job.rb
@@ -13,6 +13,8 @@ class DoiVerificationJob < ApplicationJob
       response = UnpaywallClient.query_unpaywall(publication)
       if publication.matchable_title == response.matchable_title && response.doi.present?
         publication.update!(doi: response.doi, doi_verified: true)
+      else
+        publication.update!(doi_verified: false)
       end
     end
   end

--- a/spec/component/jobs/doi_verification_job_spec.rb
+++ b/spec/component/jobs/doi_verification_job_spec.rb
@@ -67,8 +67,8 @@ describe DoiVerificationJob, type: :job do
             expect(publication.reload.doi).to be_nil
           end
 
-          it 'does not update the doi verification' do
-            expect(publication.reload.doi_verified).to be_nil
+          it 'updates the doi verification to false' do
+            expect(publication.reload.doi_verified).to eq false
           end
         end
       end
@@ -83,8 +83,8 @@ describe DoiVerificationJob, type: :job do
           expect(publication.reload.doi).to be_nil
         end
 
-        it 'does not update the doi verification' do
-          expect(publication.reload.doi_verified).to be_nil
+        it 'updates the doi verification to false' do
+          expect(publication.reload.doi_verified).to eq false
         end
       end
     end

--- a/spec/component/jobs/doi_verification_job_spec.rb
+++ b/spec/component/jobs/doi_verification_job_spec.rb
@@ -68,7 +68,7 @@ describe DoiVerificationJob, type: :job do
           end
 
           it 'updates the doi verification to false' do
-            expect(publication.reload.doi_verified).to eq false
+            expect(publication.reload.doi_verified).to be false
           end
         end
       end
@@ -84,7 +84,7 @@ describe DoiVerificationJob, type: :job do
         end
 
         it 'updates the doi verification to false' do
-          expect(publication.reload.doi_verified).to eq false
+          expect(publication.reload.doi_verified).to be false
         end
       end
     end


### PR DESCRIPTION
I went back and forth on how to accomplish the behavior that I think that want here. Ultimately I think that the list should continue to behave the way that it currently does and only show publications with `doi_verified: false`, and the DOI verification job should set the flag to false if the publication doesn't have a DOI and the job couldn't find one - that way, every publication that comes out of the automated DOI check should have the verified flag set to either true or false.