### PR TITLE
Grab permissions regardless of stored file versions

### DIFF
--- a/app/jobs/permissions_check_job.rb
+++ b/app/jobs/permissions_check_job.rb
@@ -3,19 +3,15 @@
 class PermissionsCheckJob < ApplicationJob
   queue_as 'default'
 
-  def perform(file_id)
-    file = ActivityInsightOAFile.find(file_id)
-    publication = file.publication
+  def perform(publication_id)
+    publication = Publication.find(publication_id)
     permissions = OABPreferredPermissionsService.new(publication.doi_url_path)
+
     publication.preferred_version = permissions.preferred_version
+    publication.set_statement = permissions.set_statement
+    publication.licence = permissions.licence
+    publication.embargo_date = permissions.embargo_end_date
 
-    if permissions.preferred_version == file.version
-      publication.set_statement = permissions.set_statement
-      publication.licence = permissions.licence
-      publication.embargo_date = permissions.embargo_end_date
-    end
-
-    publication.permissions_last_checked_at = Time.current
     publication.save!
   end
 end

--- a/app/models/activity_insight_oa_file.rb
+++ b/app/models/activity_insight_oa_file.rb
@@ -3,7 +3,4 @@
 class ActivityInsightOAFile < ApplicationRecord
   belongs_to :publication,
              inverse_of: :activity_insight_oa_files
-
-  scope :pub_without_permissions, -> { left_outer_joins(:publication).where(publication: { licence: nil }).where(publication: { doi_verified: true }) }
-  scope :needs_permissions_check, -> { pub_without_permissions.where(version_checked: nil).where(%{version = ? OR version = ?}, I18n.t('file_versions.accepted_version'), I18n.t('file_versions.published_version')) }
 end

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -146,6 +146,7 @@ class Publication < ApplicationRecord
   scope :activity_insight_oa_publication, -> { oa_publication.with_no_oa_locations.joins(:activity_insight_oa_files).where.not(activity_insight_oa_files: { location: nil }) }
   scope :doi_failed_verification, -> { activity_insight_oa_publication.where('doi_verified = false') }
   scope :needs_doi_verification, -> { activity_insight_oa_publication.where(doi_verified: nil).where(%{oa_workflow_state IS DISTINCT FROM 'automatic DOI verification pending'}) }
+  scope :needs_permissions_check, -> { activity_insight_oa_publication.where(licence: nil).where(doi_verified: true).where(permissions_last_checked_at: nil) }
   scope :needs_oa_metadata_search,
         -> {
           activity_insight_oa_publication

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -146,7 +146,7 @@ class Publication < ApplicationRecord
   scope :activity_insight_oa_publication, -> { oa_publication.with_no_oa_locations.joins(:activity_insight_oa_files).where.not(activity_insight_oa_files: { location: nil }) }
   scope :doi_failed_verification, -> { activity_insight_oa_publication.where('doi_verified = false') }
   scope :needs_doi_verification, -> { activity_insight_oa_publication.where(doi_verified: nil).where(%{oa_workflow_state IS DISTINCT FROM 'automatic DOI verification pending'}) }
-  scope :needs_permissions_check, -> { activity_insight_oa_publication.where(licence: nil).where(doi_verified: true).where(permissions_last_checked_at: nil) }
+  scope :needs_permissions_check, -> { activity_insight_oa_publication.where(licence: nil, doi_verified: true, permissions_last_checked_at: nil) }
   scope :needs_oa_metadata_search,
         -> {
           activity_insight_oa_publication

--- a/app/services/oa_workflow_service.rb
+++ b/app/services/oa_workflow_service.rb
@@ -17,12 +17,12 @@ class OAWorkflowService
       FetchOAMetadataJob.perform_later(pub.id)
     end
 
-    ActivityInsightOAFile.needs_permissions_check.each do |file|
-      file.version_checked = true
-      file.save!
-      PermissionsCheckJob.perform_later(file.id)
+    Publication.needs_permissions_check.each do |pub|
+      pub.permissions_last_checked_at = Time.current
+      pub.save!
+      PermissionsCheckJob.perform_later(pub.id)
     rescue StandardError
-      file.update_column(:version_checked, true)
+      pub.update_column(:permissions_last_checked_at, Time.current)
       raise
     end
   end

--- a/db/migrate/20230228215351_remove_version_checked_from_activity_insight_oa_files_and_add_version_permissions_checked_to_publications.rb
+++ b/db/migrate/20230228215351_remove_version_checked_from_activity_insight_oa_files_and_add_version_permissions_checked_to_publications.rb
@@ -1,0 +1,5 @@
+class RemoveVersionCheckedFromActivityInsightOAFilesAndAddVersionPermissionsCheckedToPublications < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :activity_insight_oa_files, :version_checked, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_02_14_202412) do
+ActiveRecord::Schema.define(version: 2023_02_28_215351) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -50,7 +50,6 @@ ActiveRecord::Schema.define(version: 2023_02_14_202412) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "version"
-    t.boolean "version_checked"
     t.index ["publication_id"], name: "index_activity_insight_oa_files_on_publication_id"
   end
 

--- a/spec/component/jobs/permissions_check_job_spec.rb
+++ b/spec/component/jobs/permissions_check_job_spec.rb
@@ -15,31 +15,17 @@ describe PermissionsCheckJob, type: :job do
   describe '#perform_now' do
     let!(:publication) { create(:publication,
                                 doi: 'https://doi.org/10.1016/S0962-1849(05)80014-9')}
-    let!(:file1) { create(:activity_insight_oa_file, publication: publication, version: 'acceptedVersion') }
-    let!(:file2) { create(:activity_insight_oa_file, publication: publication, version: 'publishedVersion') }
 
     before do
       allow(HTTParty).to receive(:get).with('https://api.openaccessbutton.org/permissions/10.1016%2FS0962-1849%2805%2980014-9')
         .and_return(Rails.root.join('spec', 'fixtures', 'oab6.json').read)
     end
 
-    context 'when the preferred version is the correct version' do
-      it 'updates the publication permissions' do
-        job.perform_now(file1.id)
-        expect(publication.reload.permissions_last_checked_at).to be_within(1.minute).of(Time.zone.now)
-        expect(publication.reload.preferred_version).to eq 'acceptedVersion'
-        expect(publication.reload.set_statement).to eq '© This manuscript version is made available under the CC-BY-NC-ND 4.0 license https://creativecommons.org/licenses/by-nc-nd/4.0/'
-        expect(publication.reload.licence).to eq 'https://creativecommons.org/licenses/by-nc-nd/4.0/'
-      end
-    end
-
-    context 'when the preferred version is not the correct version' do
-      it 'does not update the publication permissions' do
-        job.perform_now(file2.id)
-        expect(publication.reload.permissions_last_checked_at).to be_within(1.minute).of(Time.zone.now)
-        expect(publication.reload.set_statement).to be_nil
-        expect(publication.reload.licence).to be_nil
-      end
+    it 'updates the publication permissions' do
+      job.perform_now(publication.id)
+      expect(publication.reload.preferred_version).to eq 'acceptedVersion'
+      expect(publication.reload.set_statement).to eq '© This manuscript version is made available under the CC-BY-NC-ND 4.0 license https://creativecommons.org/licenses/by-nc-nd/4.0/'
+      expect(publication.reload.licence).to eq 'https://creativecommons.org/licenses/by-nc-nd/4.0/'
     end
   end
 end

--- a/spec/component/models/activity_insight_oa_file_spec.rb
+++ b/spec/component/models/activity_insight_oa_file_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe ActivityInsightOAFile, type: :model do
   it { is_expected.to have_db_column(:created_at).of_type(:datetime).with_options(null: false) }
   it { is_expected.to have_db_column(:updated_at).of_type(:datetime).with_options(null: false) }
   it { is_expected.to have_db_column(:version).of_type(:string) }
-  it { is_expected.to have_db_column(:version_checked).of_type(:boolean) }
 
   it { is_expected.to have_db_foreign_key(:publication_id) }
   it { is_expected.to have_db_index :publication_id }
@@ -19,40 +18,5 @@ RSpec.describe ActivityInsightOAFile, type: :model do
 
   describe 'associations' do
     it { is_expected.to belong_to(:publication).inverse_of(:activity_insight_oa_files) }
-  end
-
-  describe 'scopes' do
-    let!(:pub1) { create(:publication,
-                         title: 'pub1',
-                         licence: nil,
-                         doi_verified: true)
-    }
-    let!(:pub2) { create(:publication,
-                         title: 'pub2',
-                         licence: 'licence')
-    }
-    let!(:pub3) { create(:publication,
-                         title: 'pub3',
-                         doi_verified: nil)
-    }
-    let!(:file1) { create(:activity_insight_oa_file, publication: pub1) }
-    let!(:file2) { create(:activity_insight_oa_file, publication: pub2) }
-    let!(:file3) { create(:activity_insight_oa_file, publication: pub1, version: 'acceptedVersion') }
-    let!(:file4) { create(:activity_insight_oa_file, publication: pub1, version: 'publishedVersion') }
-    let!(:file5) { create(:activity_insight_oa_file, publication: pub1, version: 'unknown') }
-    let!(:file6) { create(:activity_insight_oa_file, publication: pub1, version: 'acceptedVersion', version_checked: true) }
-    let!(:file7) { create(:activity_insight_oa_file, publication: pub3) }
-
-    describe '.pub_without_permissions' do
-      it 'returns files where the publication does not have permissions data' do
-        expect(described_class.pub_without_permissions).to match_array [file1, file3, file4, file5, file6]
-      end
-    end
-
-    describe '.needs_permissions_check' do
-      it 'returns files that have not been checked that are accepted or published version' do
-        expect(described_class.needs_permissions_check).to match_array [file3, file4]
-      end
-    end
   end
 end

--- a/spec/component/models/publication_spec.rb
+++ b/spec/component/models/publication_spec.rb
@@ -516,23 +516,43 @@ describe Publication, type: :model do
                          title: 'pub7',
                          publication_type: 'Trade Journal Article')
     }
+    let!(:pub8) { create(:publication,
+      title: 'pub8',
+      licence: nil,
+      doi_verified: true)
+    }
+    let!(:pub9) { create(:publication,
+      title: 'pub9',
+      licence: nil,
+      doi_verified: true,
+      permissions_last_checked_at: DateTime.now)
+    }
+    let!(:pub10) { create(:publication,
+      title: 'pub10',
+      licence: 'licence',
+      doi_verified: true)
+    }
+    
     let!(:activity_insight_oa_file1) { create(:activity_insight_oa_file, publication: pub2) }
     let!(:activity_insight_oa_file2) { create(:activity_insight_oa_file, publication: pub3) }
     let!(:activity_insight_oa_file3) { create(:activity_insight_oa_file, publication: pub4) }
     let!(:activity_insight_oa_file4) { create(:activity_insight_oa_file, publication: pub6) }
     let!(:activity_insight_oa_file5) { create(:activity_insight_oa_file, publication: pub7) }
+    let!(:activity_insight_oa_file6) { create(:activity_insight_oa_file, publication: pub8) }
+    let!(:activity_insight_oa_file7) { create(:activity_insight_oa_file, publication: pub9) }
+    let!(:activity_insight_oa_file8) { create(:activity_insight_oa_file, publication: pub10) }
 
     let!(:open_access_location) { create(:open_access_location, publication: pub5) }
 
     describe '.with_no_oa_locations' do
       it 'returns publications that do not have open access information' do
-        expect(described_class.with_no_oa_locations).to match_array [pub1, pub2, pub3, pub4, pub6, pub7]
+        expect(described_class.with_no_oa_locations).to match_array [pub1, pub2, pub3, pub4, pub6, pub7, pub8, pub9, pub10]
       end
     end
 
     describe '.activity_insight_oa_publication' do
       it 'returns not_open_access publications that are linked to an activity insight oa file with a location' do
-        expect(described_class.activity_insight_oa_publication).to match_array [pub2, pub3, pub4, pub6]
+        expect(described_class.activity_insight_oa_publication).to match_array [pub2, pub3, pub4, pub6, pub8, pub9, pub10]
       end
     end
 
@@ -550,7 +570,13 @@ describe Publication, type: :model do
 
     describe '.needs_oa_metadata_search' do
       it 'returns activity_insight_oa_publications with a verified doi that have not been checked' do
-        expect(described_class.needs_oa_metadata_search).to match_array [pub6]
+        expect(described_class.needs_oa_metadata_search).to match_array [pub6, pub8, pub9, pub10]
+      end
+    end
+
+    describe '.needs_permissions_check' do
+      it 'returns files that have had their permissions checked' do
+        expect(described_class.needs_permissions_check).to match_array [pub8, pub3, pub6]
       end
     end
   end

--- a/spec/component/models/publication_spec.rb
+++ b/spec/component/models/publication_spec.rb
@@ -517,22 +517,22 @@ describe Publication, type: :model do
                          publication_type: 'Trade Journal Article')
     }
     let!(:pub8) { create(:publication,
-      title: 'pub8',
-      licence: nil,
-      doi_verified: true)
+                         title: 'pub8',
+                         licence: nil,
+                         doi_verified: true)
     }
     let!(:pub9) { create(:publication,
-      title: 'pub9',
-      licence: nil,
-      doi_verified: true,
-      permissions_last_checked_at: DateTime.now)
+                         title: 'pub9',
+                         licence: nil,
+                         doi_verified: true,
+                         permissions_last_checked_at: DateTime.now)
     }
     let!(:pub10) { create(:publication,
-      title: 'pub10',
-      licence: 'licence',
-      doi_verified: true)
+                          title: 'pub10',
+                          licence: 'licence',
+                          doi_verified: true)
     }
-    
+
     let!(:activity_insight_oa_file1) { create(:activity_insight_oa_file, publication: pub2) }
     let!(:activity_insight_oa_file2) { create(:activity_insight_oa_file, publication: pub3) }
     let!(:activity_insight_oa_file3) { create(:activity_insight_oa_file, publication: pub4) }

--- a/spec/component/services/oa_workflow_service_spec.rb
+++ b/spec/component/services/oa_workflow_service_spec.rb
@@ -14,11 +14,13 @@ describe OAWorkflowService do
     let!(:pub3) { create(:publication,
                          title: 'pub3',
                          doi_verified: true,
+                         permissions_last_checked_at: DateTime.now,
                          oa_status_last_checked_at: Time.now - (1 * 60 * 30))}
     let!(:pub4) { create(:publication,
                          title: 'pub4',
                          doi_verified: nil,
-                         oa_workflow_state: nil)}
+                         oa_workflow_state: nil,
+                         permissions_last_checked_at: DateTime.now)}
     let!(:pub5) { create(:publication,
                          title: 'pub5',
                          doi_verified: nil,
@@ -28,18 +30,13 @@ describe OAWorkflowService do
                          title: 'pub6',
                          doi_verified: true,
                          oa_workflow_state: nil)}
-    let!(:pub7) { create(:publication,
-                         title: 'pub7',
-                         doi_verified: true,
-                         permissions_last_checked_at: nil)}
     let!(:open_access_location) { create(:open_access_location, publication: pub1) }
 
-    let!(:activity_insight_oa_file1) { create(:activity_insight_oa_file, publication: pub2, version: 'publishedVersion') }
-    let!(:activity_insight_oa_file2) { create(:activity_insight_oa_file, publication: pub3, version: nil) }
-    let!(:activity_insight_oa_file3) { create(:activity_insight_oa_file, publication: pub4, version: 'publishedVersion', version_checked: true) }
-    let!(:activity_insight_oa_file4) { create(:activity_insight_oa_file, publication: pub5, version: 'acceptedVersion') }
+    let!(:activity_insight_oa_file1) { create(:activity_insight_oa_file, publication: pub2) }
+    let!(:activity_insight_oa_file2) { create(:activity_insight_oa_file, publication: pub3) }
+    let!(:activity_insight_oa_file3) { create(:activity_insight_oa_file, publication: pub4) }
+    let!(:activity_insight_oa_file4) { create(:activity_insight_oa_file, publication: pub5) }
     let!(:activity_insight_oa_file5) { create(:activity_insight_oa_file, publication: pub6) }
-    let!(:activity_insight_oa_file6) { create(:activity_insight_oa_file, publication: pub7, version: 'acceptedVersion', version_checked: nil) }
 
     context 'when publications need doi verification' do
       before do
@@ -54,6 +51,7 @@ describe OAWorkflowService do
         expect(DOIVerificationJob).not_to have_received(:perform_later).with(pub3.id)
         expect(DOIVerificationJob).to have_received(:perform_later).with(pub4.id)
         expect(DOIVerificationJob).not_to have_received(:perform_later).with(pub5.id)
+        expect(DOIVerificationJob).not_to have_received(:perform_later).with(pub6.id)
       end
 
       context 'when there is an error' do
@@ -73,21 +71,22 @@ describe OAWorkflowService do
 
         it 'calls the permissions check job with that publication' do
           service.workflow
-          expect(PermissionsCheckJob).not_to have_received(:perform_later).with(activity_insight_oa_file1.id)
-          expect(PermissionsCheckJob).not_to have_received(:perform_later).with(activity_insight_oa_file2.id)
-          expect(PermissionsCheckJob).not_to have_received(:perform_later).with(activity_insight_oa_file3.id)
-          expect(PermissionsCheckJob).not_to have_received(:perform_later).with(activity_insight_oa_file4.id)
-          expect(PermissionsCheckJob).to have_received(:perform_later).with(activity_insight_oa_file6.id)
+          expect(PermissionsCheckJob).not_to have_received(:perform_later).with(pub1.id)
+          expect(PermissionsCheckJob).not_to have_received(:perform_later).with(pub2.id)
+          expect(PermissionsCheckJob).not_to have_received(:perform_later).with(pub3.id)
+          expect(PermissionsCheckJob).not_to have_received(:perform_later).with(pub4.id)
+          expect(PermissionsCheckJob).not_to have_received(:perform_later).with(pub5.id)
+          expect(PermissionsCheckJob).to have_received(:perform_later).with(pub6.id)
         end
       end
 
       context 'when there is an error' do
         before { allow(PermissionsCheckJob).to receive(:perform_later).and_raise(RuntimeError) }
 
-        it 'updates file version checked' do
+        it 'updates permissions_last_checked_at checked' do
           service.workflow
         rescue RuntimeError
-          expect(activity_insight_oa_file6.reload.version_checked).to be true
+          expect(pub6.reload.permissions_last_checked_at).to be_present
         end
       end
     end


### PR DESCRIPTION
Grabbing permissions per publication rather than per file.  The permissions are pulled and stored with the publication regardless of the versions of the files we have stored.