### PR TITLE
Detect new files when importing Activity Insight OA Files

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -158,6 +158,7 @@ RSpec/MessageSpies:
     - 'spec/component/services/scholarsphere_deposit_service_spec.rb'
     - 'spec/component/models/duplicate_publication_group_spec.rb'
     - 'spec/component/jobs/doi_verification_job_spec.rb'
+    - 'spec/component/importers/activity_insight_importer_spec.rb'
 
 # Offense count: 40
 RSpec/MultipleDescribes:

--- a/app/importers/activity_insight_importer.rb
+++ b/app/importers/activity_insight_importer.rb
@@ -203,13 +203,10 @@ class ActivityInsightImporter
 
           activity_insight_file_location = pub.postprints&.first&.location
 
-          if pub_record.no_open_access_information? && activity_insight_file_location.present? && Publication.oa_publication_types.include?(pub_record.publication_type)
-            aif = pub_record.activity_insight_oa_files.first
+          if activity_insight_file_location.present? && pub_record.can_receive_new_ai_oa_files?
+            aif = pub_record.activity_insight_oa_files.find_by(location: activity_insight_file_location)
 
-            if aif.present?
-              aif.update location: activity_insight_file_location
-              aif.save!
-            else
+            unless aif.present?
               file = ActivityInsightOAFile.create(location: activity_insight_file_location)
               pub_record.activity_insight_oa_files << file
               pub_record.save!

--- a/app/importers/activity_insight_importer.rb
+++ b/app/importers/activity_insight_importer.rb
@@ -210,7 +210,11 @@ class ActivityInsightImporter
               file = ActivityInsightOAFile.create(location: activity_insight_file_location)
               pub_record.activity_insight_oa_files << file
               pub_record.save!
-              DOIVerificationJob.perform_later(pub_record.id)
+              unless pub_record.doi_verified == true
+                pub_record.oa_workflow_state = 'automatic DOI verification pending'
+                pub_record.save!
+                DOIVerificationJob.perform_later(pub_record.id)
+              end
             end
           end
         end

--- a/app/importers/activity_insight_importer.rb
+++ b/app/importers/activity_insight_importer.rb
@@ -206,7 +206,7 @@ class ActivityInsightImporter
           if activity_insight_file_location.present? && pub_record.can_receive_new_ai_oa_files?
             aif = pub_record.activity_insight_oa_files.find_by(location: activity_insight_file_location)
 
-            unless aif.present?
+            if aif.blank?
               file = ActivityInsightOAFile.create(location: activity_insight_file_location)
               pub_record.activity_insight_oa_files << file
               pub_record.save!

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -654,6 +654,10 @@ class Publication < ApplicationRecord
     secondary_title.present? ? MatchableFormatter.new(secondary_title).format : ''
   end
 
+  def can_receive_new_ai_oa_files?
+    no_open_access_information? && is_oa_publication? && no_valid_file_version?
+  end
+
   def self.filter_by_activity_insight_id(query, activity_insight_id)
     query.joins(:imports)
       .where(publication_imports: {
@@ -793,5 +797,9 @@ class Publication < ApplicationRecord
           errors.add(:doi, I18n.t('models.publication.validation_errors.doi_format'))
         end
       end
+    end
+
+    def no_valid_file_version?
+      !(preferred_version.present? && activity_insight_oa_files.collect(&:version).include?(preferred_version))
     end
 end

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -800,6 +800,6 @@ class Publication < ApplicationRecord
     end
 
     def no_valid_file_version?
-      !(preferred_version.present? && activity_insight_oa_files.collect(&:version).include?(preferred_version))
+      !(preferred_version.present? && activity_insight_oa_files.map(&:version).include?(preferred_version))
     end
 end

--- a/spec/component/importers/activity_insight_importer_spec.rb
+++ b/spec/component/importers/activity_insight_importer_spec.rb
@@ -4996,11 +4996,11 @@ describe ActivityInsightImporter do
                                        publication: existing_pub,
                                        location: 'abc123/intellcont/file.pdf') }
 
-          it 'does not update the ActivityInsightOAFile location for that publication' do
+          it 'does not create a ActivityInsightOAFile for that publication' do
             expect(existing_aif).not_to receive(:save!)
             importer.call
 
-            expect(existing_aif.reload.location).to eq('abc123/intellcont/file.pdf')
+            expect(existing_pub.reload.activity_insight_oa_files.map(&:location)).to eq(['abc123/intellcont/file.pdf'])
           end
         end
 
@@ -5009,26 +5009,25 @@ describe ActivityInsightImporter do
                                        publication: existing_pub,
                                        location: 'abc123/intellcont/some_other_file.pdf') }
 
-          it 'creates a new ActivityInsightOAFile location for that publication' do
+          it 'creates a new ActivityInsightOAFile for that publication' do
             importer.call
 
             expect(existing_pub.reload.activity_insight_oa_files.map(&:location).sort).to eq(['abc123/intellcont/file.pdf',
                                                                                               'abc123/intellcont/some_other_file.pdf'].sort)
           end
-        end
 
-        context 'when existing ActivityInsightOAFile already has a valid file version' do
-          let!(:existing_aif) { create(:activity_insight_oa_file,
-                                       publication: existing_pub,
-                                       location: 'abc123/intellcont/some_other_file.pdf',
-                                       version: 'acceptedVersion') }
-
-          it 'does not update the ActivityInsightOAFile location for that publication' do
-            existing_pub.update preferred_version: 'acceptedVersion'
-            expect(existing_aif).not_to receive(:save!)
-            importer.call
-
-            expect(existing_aif.reload.location).to eq('abc123/intellcont/some_other_file.pdf')
+          context 'when existing ActivityInsightOAFile already has a valid file version' do
+            before do
+              existing_pub.update preferred_version: 'acceptedVersion'
+              existing_aif.update version: 'acceptedVersion'
+            end
+  
+            it 'does not create an ActivityInsightOAFile location for that publication' do
+              expect(existing_aif).not_to receive(:save!)
+              importer.call
+  
+              expect(existing_pub.reload.activity_insight_oa_files.map(&:location)).to eq(['abc123/intellcont/some_other_file.pdf'])
+            end
           end
         end
       end

--- a/spec/component/importers/activity_insight_importer_spec.rb
+++ b/spec/component/importers/activity_insight_importer_spec.rb
@@ -5021,11 +5021,11 @@ describe ActivityInsightImporter do
               existing_pub.update preferred_version: 'acceptedVersion'
               existing_aif.update version: 'acceptedVersion'
             end
-  
+
             it 'does not create an ActivityInsightOAFile location for that publication' do
               expect(existing_aif).not_to receive(:save!)
               importer.call
-  
+
               expect(existing_pub.reload.activity_insight_oa_files.map(&:location)).to eq(['abc123/intellcont/some_other_file.pdf'])
             end
           end

--- a/spec/component/importers/activity_insight_importer_spec.rb
+++ b/spec/component/importers/activity_insight_importer_spec.rb
@@ -5012,8 +5012,8 @@ describe ActivityInsightImporter do
           it 'creates a new ActivityInsightOAFile location for that publication' do
             importer.call
 
-            expect(existing_pub.reload.activity_insight_oa_files.collect(&:location).sort).to eq(['abc123/intellcont/file.pdf', 'abc123/intellcont/some_other_file.pdf'].sort)
-            expect(existing_pub.reload.activity_insight_oa_files.count).to eq 2
+            expect(existing_pub.reload.activity_insight_oa_files.map(&:location).sort).to eq(['abc123/intellcont/file.pdf',
+                                                                                              'abc123/intellcont/some_other_file.pdf'].sort)
           end
         end
 
@@ -5030,7 +5030,7 @@ describe ActivityInsightImporter do
 
             expect(existing_aif.reload.location).to eq('abc123/intellcont/some_other_file.pdf')
           end
-        end     
+        end
       end
     end
   end

--- a/spec/component/importers/activity_insight_importer_spec.rb
+++ b/spec/component/importers/activity_insight_importer_spec.rb
@@ -4959,7 +4959,7 @@ describe ActivityInsightImporter do
           expect(p5.doi_verified).to be_nil
         end
 
-        it 'does not import ActivityInsightOAFiles for imported publications without an open access publication type' do
+        it 'does not import ActivityInsightOAFiles for imported publications without an open access publication type (cannot receive new ai oa files)' do
           importer.call
           p2 = PublicationImport.find_by(source: 'Activity Insight',
                                          source_identifier: '92747188475').publication
@@ -4975,7 +4975,7 @@ describe ActivityInsightImporter do
                                       publication: existing_pub) }
       let!(:existing_pub) { create(:publication) }
 
-      context 'when the existing publication is already open access' do
+      context 'when the existing publication cannot receive new ai oa files?' do
         let(:oal) { create(:open_access_location) }
 
         before do
@@ -4990,8 +4990,8 @@ describe ActivityInsightImporter do
         end
       end
 
-      context 'when the existing publication is not open access' do
-        context 'when existing ActivityInsightOAFile has same locationas imported file' do
+      context 'when the existing publication can_receive_new_ai_oa_files?' do
+        context 'when existing ActivityInsightOAFile has same location as imported file' do
           let!(:existing_aif) { create(:activity_insight_oa_file,
                                        publication: existing_pub,
                                        location: 'abc123/intellcont/file.pdf') }
@@ -5001,6 +5001,19 @@ describe ActivityInsightImporter do
             importer.call
 
             expect(existing_aif.reload.location).to eq('abc123/intellcont/file.pdf')
+          end
+        end
+
+        context 'when existing ActivityInsightOAFile does not have the same location as the imported file' do
+          let!(:existing_aif) { create(:activity_insight_oa_file,
+                                       publication: existing_pub,
+                                       location: 'abc123/intellcont/some_other_file.pdf') }
+
+          it 'creates a new ActivityInsightOAFile location for that publication' do
+            importer.call
+
+            expect(existing_pub.reload.activity_insight_oa_files.collect(&:location).sort).to eq(['abc123/intellcont/file.pdf', 'abc123/intellcont/some_other_file.pdf'].sort)
+            expect(existing_pub.reload.activity_insight_oa_files.count).to eq 2
           end
         end
 
@@ -5017,7 +5030,7 @@ describe ActivityInsightImporter do
 
             expect(existing_aif.reload.location).to eq('abc123/intellcont/some_other_file.pdf')
           end
-        end
+        end     
       end
     end
   end

--- a/spec/component/models/publication_spec.rb
+++ b/spec/component/models/publication_spec.rb
@@ -3110,4 +3110,61 @@ describe Publication, type: :model do
       expect(pub.matchable_secondary_title).to eq 'secondarytitleatest'
     end
   end
+
+  describe '#can_receive_new_ai_oa_files?' do
+    context 'when publication is not able to receive new activity insight oa files' do
+      context 'when publication has open access information' do
+        let!(:publication) { create(:publication, :oa_publication, :with_open_access_location, preferred_version: 'acceptedVersion') }
+
+        it 'returns false' do
+          expect(publication.can_receive_new_ai_oa_files?).to be false
+        end
+      end
+
+      context 'when publication is not an oa_publication' do
+        let!(:publication) { create(:publication, :other_work, preferred_version: 'acceptedVersion') }
+
+        it 'returns false' do
+          expect(publication.can_receive_new_ai_oa_files?).to be false
+        end
+      end
+
+      context 'when publication has associated file that matches preferred_version' do
+        let!(:publication) { create(:publication, :oa_publication, preferred_version: 'acceptedVersion') }
+        let!(:activity_insight_oa_file) { create(:activity_insight_oa_file, publication: publication, version: 'acceptedVersion') }
+
+        it 'returns false' do
+          expect(publication.can_receive_new_ai_oa_files?).to be false
+        end
+      end
+    end
+
+    context 'when publication is able to receive new activity insight oa files' do
+      context 'when the publication has no activity insight oa files' do
+        let!(:publication) { create(:publication, :oa_publication) }
+
+        it 'returns true' do
+          expect(publication.can_receive_new_ai_oa_files?).to be true
+        end
+      end
+
+      context "when the publication has no activity insight oa files with a version that matches the publication's preferred_version" do
+        let!(:publication) { create(:publication, :oa_publication, preferred_version: 'acceptedVersion') }
+        let!(:activity_insight_oa_file) { create(:activity_insight_oa_file, publication: publication, version: 'publishedVersion') }
+
+        it 'returns true' do
+          expect(publication.can_receive_new_ai_oa_files?).to be true
+        end
+      end
+
+      context 'when publication has no preferred_version and file has no version' do
+        let!(:publication) { create(:publication, :oa_publication, preferred_version: nil) }
+        let!(:activity_insight_oa_file) { create(:activity_insight_oa_file, publication: publication, version: nil) }
+
+        it 'returns true' do
+          expect(publication.can_receive_new_ai_oa_files?).to be true
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Adds criteria for when _not_ to import an Activity Insight OA File:

- When an existing file exists and it is the correct/valid version
- When the `location` of the file being imported is the same as the `location` of the existing file  

These changes will make it so the OA Workflow can "reset" (or atleast reset back to the file version checking stage) if someone originally uploaded the wrong version, deletes this file in Activity Insight, and uploads a new file that is hopefully the correct version.

closes #693