### PR TITLE
Fix failing glacial test

### DIFF
--- a/spec/component/models/orcid_integration_spec.rb
+++ b/spec/component/models/orcid_integration_spec.rb
@@ -39,9 +39,13 @@ describe OrcidAPIClient do
     }
     let(:employments_uri) { "#{described_class.base_uri}/#{resource.orcid_id}/employments" }
     let(:get_employments) { client.class.get(employments_uri, headers).parsed_response }
-    let(:employments_hash) { Hash.from_xml(get_employments) }
-    let(:json_resource) { JSON.parse(resource.to_json.gsub('-', '_')) }
-    let(:employment_summary) { employments_hash['employments']['affiliation_group'].last['employment_summary'] }
+    let(:employments_hash) { JSON.parse(get_employments) }
+    let(:json_resource) { JSON.parse(resource.to_json) }
+    let(:employment_path) do 
+      employments_hash["affiliation-group"].sort_by { |l| l["summaries"].last["employment-summary"]["path"] }
+                                           .last["summaries"].last["employment-summary"]["path"]
+    end
+    let(:employment_summary) { employments_hash["affiliation-group"].last["summaries"].last["employment-summary"] }
 
     after do
       delete_employ_uri = employments_uri[0..-2].to_s + "/#{employment_summary['put_code']}"
@@ -49,10 +53,12 @@ describe OrcidAPIClient do
     end
 
     it 'successfully POSTs to ORCID and does not return an error' do
-      expect(client.post.parsed_response).to be_nil
-      expect(employment_summary['department_name']).to eq json_resource['department_name']
-      expect(employment_summary['role_title']).to eq json_resource['role_title']
-      expect(employment_summary['organization']).to eq json_resource['organization']
+      post = client.post
+      expect(post.response.message).to eq "Created"
+      expect(post["location"]).to include employment_path
+      expect(employment_summary["department-name"]).to eq json_resource["department-name"]
+      expect(employment_summary["role-title"]).to eq json_resource["role-title"]
+      expect(employment_summary["organization"]["disambiguated-organization"]).to eq json_resource["organization"]["disambiguated-organization"]
     end
   end
 end


### PR DESCRIPTION
Now parses orcid response as json, and does a better job off asserting the response is the most recently sent record.