### PR TITLE
Fix ci

### DIFF
--- a/.rspec.ci
+++ b/.rspec.ci
@@ -1,3 +1,3 @@
-+--no-color
-+--format documentation
-+--tag ~no_ci
+--no-color
+--format documentation
+--tag ~no_ci

--- a/spec/component/jobs/publication_download_job_spec.rb
+++ b/spec/component/jobs/publication_download_job_spec.rb
@@ -12,6 +12,12 @@ describe PublicationDownloadJob, type: :job do
     end
   end
 
+  # This test is somewhat brittle and has a few dependencies that should be noted. It downloads
+  # an actual file from the production instance of Activity Insight via the Activity Insight S3
+  # Authorizer app's API. So this test will fail if the file is removed from Activity Insight or
+  # if the Activity Insight S3 Authorizer is unreachable (i.e. if you're running this test from a
+  # machine that is not on the Penn State network). The network firewall is also the reason why
+  # this test can't currently be run on the CI server.
   describe '#perform_now', no_ci: true do
     let!(:publication) { create(:publication) }
     let!(:ai_oa_file) { create(:activity_insight_oa_file, publication: publication, version: 'acceptedVersion', location: 'nmg110/intellcont/test_file-1.pdf') }


### PR DESCRIPTION
@Smullz622 Here's a small fix for the Rspec config on CI so that it properly skips our downloader test. A side effect of this is that it will enable a couple of other tests that were being skipped previously and are failing in this branch. However, @ajkiessl  should have those specs fixed in `main` shortly, so you should be able to merge this and then rebase your branch after Alex merges his changes and then everything should be running appropriately and passing on CI (I think).