### PR TITLE
Permissions review list

### DIFF
--- a/app/components/activity_insight_oa_dashboard_component.html.erb
+++ b/app/components/activity_insight_oa_dashboard_component.html.erb
@@ -34,4 +34,22 @@
       <div class='card-body'><%= i18n('file_version_curation_description') %></div>
     </div>
   <% end %>
+  <br>
+  <% if permissions_check_failed_count.nonzero? %>
+    <%= link_to activity_insight_oa_workflow_permissions_review_path, class: 'card-link' do %>
+      <div class='card' id='permissions-check-card'>
+        <div class='card-header'><strong><%= i18n('permissions_curation_title') %></strong>
+          <span class='float-right text-large'><strong><%= permissions_check_failed_count %></strong></span>
+        </div>
+        <div class='card-body'><%= i18n('permissions_curation_description') %></div>
+      </div>
+    <% end %>
+  <% else %>
+    <div class='card text-muted' id='permissions-check-card'>
+      <div class='card-header'><strong><%= i18n('permissions_curation_title') %></strong>
+        <span class='float-right text-large'>0</strong></span>
+      </div>
+      <div class='card-body'><%= i18n('permissions_curation_description') %></div>
+    </div>
+  <% end %>
 </div>

--- a/app/components/activity_insight_oa_dashboard_component.rb
+++ b/app/components/activity_insight_oa_dashboard_component.rb
@@ -9,6 +9,10 @@ class ActivityInsightOADashboardComponent < ViewComponent::Base
     Publication.file_version_check_failed.count
   end
 
+  def permissions_check_failed_count
+    Publication.permissions_check_failed.count
+  end
+
   def i18n(key, **options)
     I18n.t("view_component.#{self.class.name.underscore}.#{key}", **options)
   end

--- a/app/controllers/activity_insight_oa_workflow/permissions_curation_controller.rb
+++ b/app/controllers/activity_insight_oa_workflow/permissions_curation_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ActivityInsightOAWorkflow::PermissionsCurationController < ActivityInsightOAWorkflowController
-    def index
-      @publications = Publication.permissions_check_failed
-    end
+  def index
+    @publications = Publication.permissions_check_failed
   end
+end

--- a/app/controllers/activity_insight_oa_workflow/permissions_curation_controller.rb
+++ b/app/controllers/activity_insight_oa_workflow/permissions_curation_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ActivityInsightOAWorkflow::PermissionsCurationController < ActivityInsightOAWorkflowController
+    def index
+      @publications = Publication.permissions_check_failed
+    end
+  end

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -162,6 +162,7 @@ class Publication < ApplicationRecord
       .where(%{NOT EXISTS (SELECT * FROM activity_insight_oa_files WHERE activity_insight_oa_files.publication_id = publications.id AND activity_insight_oa_files.version IS NULL)})
   }
   scope :published, -> { where(publications: { status: PUBLISHED_STATUS }) }
+  scope :permissions_check_failed, -> { activity_insight_oa_publication.where.not(permissions_last_checked_at: nil).where(licence: nil) }
 
   accepts_nested_attributes_for :authorships, allow_destroy: true
   accepts_nested_attributes_for :contributor_names, allow_destroy: true

--- a/app/views/activity_insight_oa_workflow/permissions_curation/index.html.erb
+++ b/app/views/activity_insight_oa_workflow/permissions_curation/index.html.erb
@@ -1,0 +1,26 @@
+<div class="container pt-4 pb-5">
+  <%= link_to '<< Back', activity_insight_oa_workflow_path %>
+  <h1 class="pb-3 pt-2">Publications Requiring Permissions Review</h1>
+  <div class='card'>
+  <table class="table">
+    <thead class='card-header'>
+      <tr>
+        <th>Title</th>
+        <th>Licence</th>
+        <th>Preferred Version</th>
+      </tr>
+    </thead>
+    <tbody class='card-body'>
+      <% @publications.each do |p| %>
+        <tr id="<%= dom_id(p) %>">
+          <td><%= link_to p.title.truncate(45),
+                  rails_admin.edit_path(model_name: :publication, id: p.id),
+                  target: '_blank' %></td>
+          <td>Not Found</td>
+          <td><%= p.preferred_version || 'Not Found'%></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+  </div>
+</div>

--- a/app/views/activity_insight_oa_workflow/permissions_curation/index.html.erb
+++ b/app/views/activity_insight_oa_workflow/permissions_curation/index.html.erb
@@ -17,7 +17,7 @@
                   rails_admin.edit_path(model_name: :publication, id: p.id),
                   target: '_blank' %></td>
           <td>Not Found</td>
-          <td><%= p.preferred_version || 'Not Found'%></td>
+          <td><%= p.preferred_version || 'Not Found' %></td>
         </tr>
       <% end %>
     </tbody>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -209,6 +209,8 @@ en:
       doi_verification_description: Publications that require manual DOI curation or verification.
       file_version_curation_title: Review File Versions
       file_version_curation_description: Publications that still have an unknown file version and no correct version after automated file version checking.
+      permissions_curation_title: Review Permissions
+      permissions_curation_description: Publications that require manual permissions curation.
 
   helpers:
     submit:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
   namespace :activity_insight_oa_workflow do
     get '/doi_verification' => 'doi_verification#index'
     get '/file_version_review' => 'file_version_curation#index'
+    get '/permissions_review' => 'permissions_curation#index'
   end
 
   root to: 'public#home'

--- a/spec/component/components/activity_insight_oa_dashboard_component_spec.rb
+++ b/spec/component/components/activity_insight_oa_dashboard_component_spec.rb
@@ -55,4 +55,30 @@ RSpec.describe ActivityInsightOADashboardComponent, type: :component do
       expect(rendered_component).to have_link(href: '/activity_insight_oa_workflow/file_version_review')
     end
   end
+
+  context 'when no publications need their permissions verified' do
+    let!(:oal) { create(:open_access_location, publication: pub2) }
+    let!(:pub1) { create(:publication) }
+    let!(:pub2) { create(:publication, doi_verified: nil) }
+    let!(:pub2) { create(:publication, permissions_last_checked_at: Time.now, licence: 'licence') }
+
+    it 'renders a muted card with no link' do
+      render_inline(described_class.new)
+      expect(page.find_by_id('permissions-check-card').to_json).to include('text-muted')
+      expect(page.find_by_id('permissions-check-card').text).to include('0')
+      expect(rendered_component).not_to have_link(href: '/activity_insight_oa_workflow/permissions_review')
+    end
+  end
+
+  context 'when publications need their permissions verified' do
+    let!(:pub1) { create(:publication, permissions_last_checked_at: Time.now) }
+    let!(:pub2) { create(:publication, permissions_last_checked_at: Time.now, licence: 'licence') }
+
+    it 'renders the permissions review card with a link and the number of publications in the corner' do
+      render_inline(described_class.new)
+      expect(page.find_by_id('permissions-check-card').to_json).not_to include('text-muted')
+      expect(page.find_by_id('permissions-check-card').text).to include('1')
+      expect(rendered_component).to have_link(href: '/activity_insight_oa_workflow/permissions_review')
+    end
+  end
 end

--- a/spec/component/components/activity_insight_oa_dashboard_component_spec.rb
+++ b/spec/component/components/activity_insight_oa_dashboard_component_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe ActivityInsightOADashboardComponent, type: :component do
     let!(:oal) { create(:open_access_location, publication: pub2) }
     let!(:pub1) { create(:publication) }
     let!(:pub2) { create(:publication, doi_verified: nil) }
-    let!(:pub2) { create(:publication, permissions_last_checked_at: Time.now, licence: 'licence') }
+    let!(:pub3) { create(:publication, permissions_last_checked_at: Time.now, licence: 'licence') }
 
     it 'renders a muted card with no link' do
       render_inline(described_class.new)

--- a/spec/component/models/publication_spec.rb
+++ b/spec/component/models/publication_spec.rb
@@ -601,6 +601,12 @@ describe Publication, type: :model do
         expect(described_class.needs_permissions_check).to match_array [pub8, pub3, pub6]
       end
     end
+
+    describe '.permissions_check_failed' do
+      it 'returns activity_insight_oa_publications that have had their permissions checked but are still missing permissions data' do
+        expect(described_class.permissions_check_failed).to match_array [pub9]
+      end
+    end
   end
 
   describe '.find_by_wos_pub' do

--- a/spec/integration/admin/activity_insight_oa_workflow/dashboard_spec.rb
+++ b/spec/integration/admin/activity_insight_oa_workflow/dashboard_spec.rb
@@ -5,8 +5,10 @@ require 'integration/integration_spec_helper'
 describe 'Admin Activity Insight OA Workflow dashboard', type: :feature do
   let!(:aif1) { create(:activity_insight_oa_file, publication: pub1) }
   let!(:aif2) { create(:activity_insight_oa_file, publication: pub2, version: 'unknown') }
+  let!(:aif3) { create(:activity_insight_oa_file, publication: pub3) }
   let!(:pub1) { create(:publication, doi_verified: false) }
   let!(:pub2) { create(:publication, preferred_version: 'acceptedVersion') }
+  let!(:pub3) { create(:publication, permissions_last_checked_at: Time.now) }
 
   context 'when the current user is an admin' do
     before do
@@ -32,6 +34,13 @@ describe 'Admin Activity Insight OA Workflow dashboard', type: :feature do
       it 'redirects to the File Version Review page' do
         click_on 'Review File Versions'
         expect(page).to have_current_path activity_insight_oa_workflow_file_version_review_path
+      end
+    end
+
+    describe 'clicking the link to the Permissions Review page' do
+      it 'redirects to the Permissions Review page' do
+        click_on 'Review Permissions'
+        expect(page).to have_current_path activity_insight_oa_workflow_permissions_review_path
       end
     end
   end

--- a/spec/integration/admin/activity_insight_oa_workflow/permissions_review_spec.rb
+++ b/spec/integration/admin/activity_insight_oa_workflow/permissions_review_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'integration/integration_spec_helper'
+
+describe 'Admin Permissions Review dashboard', type: :feature do
+  let!(:aif1) { create(:activity_insight_oa_file, publication: pub1) }
+  let!(:aif2) { create(:activity_insight_oa_file, publication: pub2) }
+  let!(:pub1) { create(:publication, permissions_last_checked_at: Time.now) }
+  let!(:pub2) { create(:publication, permissions_last_checked_at: Time.now, licence: 'licence') }
+  let!(:pub3) { create(:publication, permissions_last_checked_at: Time.now) }
+
+  before do
+    authenticate_admin_user
+    visit activity_insight_oa_workflow_permissions_review_path
+  end
+
+  describe 'listing publications that need their Permissions reviewed' do
+    it 'show a table with header and the proper data for the publications in the table' do
+      expect(page).to have_text('Title')
+      expect(page).to have_text('Licence')
+      expect(page).to have_text('Preferred Version')
+      expect(page).to have_link(pub1.title)
+      expect(page).to have_text('Not Found')
+      expect(page).to have_css('tr').exactly(2).times
+    end
+  end
+
+  describe 'clicking "<< Back"' do
+    it 'redirects to the OA Workflow Dashboard' do
+      click_link '<< Back'
+      expect(page).to have_current_path activity_insight_oa_workflow_path
+    end
+  end
+
+  describe 'clicking a link to edit a publication' do
+    it "redirects to that publication's edit page" do
+      click_link pub1.title
+      expect(page).to have_current_path rails_admin.edit_path(model_name: :publication, id: pub1.id)
+    end
+  end
+end


### PR DESCRIPTION
Fixes #714 

Lists publications that have gone through permissions check but are still missing permissions data. Publication titles are linked to rails admin to edit the publication.

<img width="1165" alt="image" src="https://user-images.githubusercontent.com/64047083/223869513-14e305e5-3d03-4100-aea6-d47c056e866c.png">

Adds the card to the main dashboard

<img width="1124" alt="image" src="https://user-images.githubusercontent.com/64047083/223869926-79c3b8c8-40a7-476f-8a5a-0974ddbde8f7.png">
