### PR TITLE
Removes webaccess_id from Scholarsphere deposit metadata if user is not active

### DIFF
--- a/app/models/contributor_name.rb
+++ b/app/models/contributor_name.rb
@@ -7,7 +7,7 @@ class ContributorName < ApplicationRecord
   validates :publication, :position, presence: true
   validate :at_least_one_name_present
 
-  delegate :webaccess_id, to: :user, prefix: false, allow_nil: true
+  delegate :webaccess_id, :is_active, to: :user, prefix: false, allow_nil: true
 
   def name
     full_name = first_name.to_s
@@ -20,7 +20,7 @@ class ContributorName < ApplicationRecord
 
   def to_scholarsphere_creator
     ss_attrs = {}
-    ss_attrs[:psu_id] = webaccess_id if webaccess_id
+    ss_attrs[:psu_id] = webaccess_id if webaccess_id && is_active
     ss_attrs[:orcid] = orcid_identifier if orcid_identifier
     ss_attrs[:display_name] = name if name.present?
     ss_attrs.presence

--- a/spec/component/models/contributor_name_spec.rb
+++ b/spec/component/models/contributor_name_spec.rb
@@ -308,7 +308,7 @@ describe ContributorName, type: :model do
                 before do
                   allow(user).to receive(:is_active).and_return true
                 end
-               
+
                 it 'returns a hash with the full name, WebAccess ID, and ORCID ID of the contributor' do
                   expect(cn.to_scholarsphere_creator).to eq({ psu_id: 'abc123', orcid: 'orcidid123', display_name: 'first middle last' })
                 end
@@ -332,7 +332,7 @@ describe ContributorName, type: :model do
                 before do
                   allow(user).to receive(:is_active).and_return true
                 end
-               
+
                 it 'returns a hash with the full name, WebAccess ID, and ORCID ID of the contributor' do
                   expect(cn.to_scholarsphere_creator).to eq({ psu_id: 'abc123', orcid: 'orcidid123', display_name: 'first middle' })
                 end
@@ -360,7 +360,7 @@ describe ContributorName, type: :model do
                 before do
                   allow(user).to receive(:is_active).and_return true
                 end
-               
+
                 it 'returns a hash with the full name, WebAccess ID, and ORCID ID of the contributor' do
                   expect(cn.to_scholarsphere_creator).to eq({ psu_id: 'abc123', orcid: 'orcidid123', display_name: 'first last' })
                 end
@@ -384,7 +384,7 @@ describe ContributorName, type: :model do
                 before do
                   allow(user).to receive(:is_active).and_return true
                 end
-               
+
                 it 'returns a hash with the full name, WebAccess ID, and ORCID ID of the contributor' do
                   expect(cn.to_scholarsphere_creator).to eq({ psu_id: 'abc123', orcid: 'orcidid123', display_name: 'first' })
                 end
@@ -416,7 +416,7 @@ describe ContributorName, type: :model do
                 before do
                   allow(user).to receive(:is_active).and_return true
                 end
-               
+
                 it 'returns a hash with the full name, WebAccess ID, and ORCID ID of the contributor' do
                   expect(cn.to_scholarsphere_creator).to eq ({ psu_id: 'abc123', orcid: 'orcidid123', display_name: 'middle last' })
                 end
@@ -440,7 +440,7 @@ describe ContributorName, type: :model do
                 before do
                   allow(user).to receive(:is_active).and_return true
                 end
-               
+
                 it 'returns a hash with the full name, WebAccess ID, and ORCID ID of the contributor' do
                   expect(cn.to_scholarsphere_creator).to eq ({ psu_id: 'abc123', orcid: 'orcidid123', display_name: 'middle' })
                 end
@@ -468,7 +468,7 @@ describe ContributorName, type: :model do
                 before do
                   allow(user).to receive(:is_active).and_return true
                 end
-               
+
                 it 'returns a hash with the full name, WebAccess ID, and ORCID ID of the contributor' do
                   expect(cn.to_scholarsphere_creator).to eq ({ psu_id: 'abc123', orcid: 'orcidid123', display_name: 'last' })
                 end
@@ -504,7 +504,7 @@ describe ContributorName, type: :model do
                 before do
                   allow(user).to receive(:is_active).and_return true
                 end
-               
+
                 it 'returns a hash with the full name and WebAccess ID of the contributor' do
                   expect(cn.to_scholarsphere_creator).to eq({ psu_id: 'abc123', display_name: 'first middle last' })
                 end
@@ -528,7 +528,7 @@ describe ContributorName, type: :model do
                 before do
                   allow(user).to receive(:is_active).and_return true
                 end
-               
+
                 it 'returns a hash with the full name and WebAccess ID of the contributor' do
                   expect(cn.to_scholarsphere_creator).to eq({ psu_id: 'abc123', display_name: 'first middle' })
                 end
@@ -556,7 +556,7 @@ describe ContributorName, type: :model do
                 before do
                   allow(user).to receive(:is_active).and_return true
                 end
-               
+
                 it 'returns a hash with the full name and WebAccess ID of the contributor' do
                   expect(cn.to_scholarsphere_creator).to eq({ psu_id: 'abc123', display_name: 'first last' })
                 end
@@ -580,7 +580,7 @@ describe ContributorName, type: :model do
                 before do
                   allow(user).to receive(:is_active).and_return true
                 end
-               
+
                 it 'returns a hash with the full name and WebAccess ID of the contributor' do
                   expect(cn.to_scholarsphere_creator).to eq({ psu_id: 'abc123', display_name: 'first' })
                 end
@@ -612,7 +612,7 @@ describe ContributorName, type: :model do
                 before do
                   allow(user).to receive(:is_active).and_return true
                 end
-               
+
                 it 'returns a hash with the full name and WebAccess ID of the contributor' do
                   expect(cn.to_scholarsphere_creator).to eq ({ psu_id: 'abc123', display_name: 'middle last' })
                 end
@@ -636,7 +636,7 @@ describe ContributorName, type: :model do
                 before do
                   allow(user).to receive(:is_active).and_return true
                 end
-               
+
                 it 'returns a hash with the full name and WebAccess ID of the contributor' do
                   expect(cn.to_scholarsphere_creator).to eq ({ psu_id: 'abc123', display_name: 'middle' })
                 end
@@ -664,7 +664,7 @@ describe ContributorName, type: :model do
                 before do
                   allow(user).to receive(:is_active).and_return true
                 end
-               
+
                 it 'returns a hash with the full name and WebAccess ID of the contributor' do
                   expect(cn.to_scholarsphere_creator).to eq ({ psu_id: 'abc123', display_name: 'last' })
                 end

--- a/spec/component/models/contributor_name_spec.rb
+++ b/spec/component/models/contributor_name_spec.rb
@@ -40,6 +40,7 @@ describe ContributorName, type: :model do
   it { is_expected.to belong_to(:publication).inverse_of(:contributor_names) }
   it { is_expected.to belong_to(:user).inverse_of(:contributor_names).optional }
   it { is_expected.to delegate_method(:webaccess_id).to(:user).allow_nil }
+  it { is_expected.to delegate_method(:is_active).to(:user).allow_nil }
 
   describe 'Validating that a contributor has at least one name' do
     let(:cn) { described_class.new(publication: create(:publication),
@@ -303,16 +304,48 @@ describe ContributorName, type: :model do
             context 'when the contributor has a last name' do
               let(:ln) { 'last' }
 
-              it 'returns a hash with the full name, WebAccess ID, and ORCID ID of the contributor' do
-                expect(cn.to_scholarsphere_creator).to eq({ psu_id: 'abc123', orcid: 'orcidid123', display_name: 'first middle last' })
+              context 'when the contributor is active' do
+                before do
+                  allow(user).to receive(:is_active).and_return true
+                end
+               
+                it 'returns a hash with the full name, WebAccess ID, and ORCID ID of the contributor' do
+                  expect(cn.to_scholarsphere_creator).to eq({ psu_id: 'abc123', orcid: 'orcidid123', display_name: 'first middle last' })
+                end
+              end
+
+              context 'when the contributor is not active' do
+                before do
+                  allow(user).to receive(:is_active).and_return false
+                end
+
+                it 'returns a hash with the full name and ORCID ID of the contributor' do
+                  expect(cn.to_scholarsphere_creator).to eq({ orcid: 'orcidid123', display_name: 'first middle last' })
+                end
               end
             end
 
             context 'when the contributor has no last name' do
               let(:ln) { '' }
 
-              it 'returns a hash with the full name, WebAccess ID, and ORCID ID of the contributor' do
-                expect(cn.to_scholarsphere_creator).to eq({ psu_id: 'abc123', orcid: 'orcidid123', display_name: 'first middle' })
+              context 'when the contributor is active' do
+                before do
+                  allow(user).to receive(:is_active).and_return true
+                end
+               
+                it 'returns a hash with the full name, WebAccess ID, and ORCID ID of the contributor' do
+                  expect(cn.to_scholarsphere_creator).to eq({ psu_id: 'abc123', orcid: 'orcidid123', display_name: 'first middle' })
+                end
+              end
+
+              context 'when the contributor is not active' do
+                before do
+                  allow(user).to receive(:is_active).and_return false
+                end
+
+                it 'returns a hash with the full name and ORCID ID of the contributor' do
+                  expect(cn.to_scholarsphere_creator).to eq({ orcid: 'orcidid123', display_name: 'first middle' })
+                end
               end
             end
           end
@@ -323,16 +356,48 @@ describe ContributorName, type: :model do
             context 'when the contributor has a last name' do
               let(:ln) { 'last' }
 
-              it 'returns a hash with the full name, WebAccess ID, and ORCID ID of the contributor' do
-                expect(cn.to_scholarsphere_creator).to eq({ psu_id: 'abc123', orcid: 'orcidid123', display_name: 'first last' })
+              context 'when the contributor is active' do
+                before do
+                  allow(user).to receive(:is_active).and_return true
+                end
+               
+                it 'returns a hash with the full name, WebAccess ID, and ORCID ID of the contributor' do
+                  expect(cn.to_scholarsphere_creator).to eq({ psu_id: 'abc123', orcid: 'orcidid123', display_name: 'first last' })
+                end
+              end
+
+              context 'when the contributor is not active' do
+                before do
+                  allow(user).to receive(:is_active).and_return false
+                end
+
+                it 'returns a hash with the full name and ORCID ID of the contributor' do
+                  expect(cn.to_scholarsphere_creator).to eq({ orcid: 'orcidid123', display_name: 'first last' })
+                end
               end
             end
 
             context 'when the contributor has no last name' do
               let(:ln) { '' }
 
-              it 'returns a hash with the full name, WebAccess ID, and ORCID ID of the contributor' do
-                expect(cn.to_scholarsphere_creator).to eq({ psu_id: 'abc123', orcid: 'orcidid123', display_name: 'first' })
+              context 'when the contributor is active' do
+                before do
+                  allow(user).to receive(:is_active).and_return true
+                end
+               
+                it 'returns a hash with the full name, WebAccess ID, and ORCID ID of the contributor' do
+                  expect(cn.to_scholarsphere_creator).to eq({ psu_id: 'abc123', orcid: 'orcidid123', display_name: 'first' })
+                end
+              end
+
+              context 'when the contributor is not active' do
+                before do
+                  allow(user).to receive(:is_active).and_return false
+                end
+
+                it 'returns a hash with the full name and ORCID ID of the contributor' do
+                  expect(cn.to_scholarsphere_creator).to eq({ orcid: 'orcidid123', display_name: 'first' })
+                end
               end
             end
           end
@@ -347,16 +412,48 @@ describe ContributorName, type: :model do
             context 'when the contributor has a last name' do
               let(:ln) { 'last' }
 
-              it 'returns a hash with the full name, WebAccess ID, and ORCID ID of the contributor' do
-                expect(cn.to_scholarsphere_creator).to eq ({ psu_id: 'abc123', orcid: 'orcidid123', display_name: 'middle last' })
+              context 'when the contributor is active' do
+                before do
+                  allow(user).to receive(:is_active).and_return true
+                end
+               
+                it 'returns a hash with the full name, WebAccess ID, and ORCID ID of the contributor' do
+                  expect(cn.to_scholarsphere_creator).to eq ({ psu_id: 'abc123', orcid: 'orcidid123', display_name: 'middle last' })
+                end
+              end
+
+              context 'when the contributor is not active' do
+                before do
+                  allow(user).to receive(:is_active).and_return false
+                end
+
+                it 'returns a hash with the full name and ORCID ID of the contributor' do
+                  expect(cn.to_scholarsphere_creator).to eq ({ orcid: 'orcidid123', display_name: 'middle last' })
+                end
               end
             end
 
             context 'when the contributor has no last name' do
               let(:ln) { '' }
 
-              it 'returns a hash with the full name, WebAccess ID, and ORCID ID of the contributor' do
-                expect(cn.to_scholarsphere_creator).to eq ({ psu_id: 'abc123', orcid: 'orcidid123', display_name: 'middle' })
+              context 'when the contributor is active' do
+                before do
+                  allow(user).to receive(:is_active).and_return true
+                end
+               
+                it 'returns a hash with the full name, WebAccess ID, and ORCID ID of the contributor' do
+                  expect(cn.to_scholarsphere_creator).to eq ({ psu_id: 'abc123', orcid: 'orcidid123', display_name: 'middle' })
+                end
+              end
+
+              context 'when the contributor is not active' do
+                before do
+                  allow(user).to receive(:is_active).and_return false
+                end
+
+                it 'returns a hash with the full name and ORCID ID of the contributor' do
+                  expect(cn.to_scholarsphere_creator).to eq ({ orcid: 'orcidid123', display_name: 'middle' })
+                end
               end
             end
           end
@@ -367,8 +464,24 @@ describe ContributorName, type: :model do
             context 'when the contributor has a last name' do
               let(:ln) { 'last' }
 
-              it 'returns a hash with the full name, WebAccess ID, and ORCID ID of the contributor' do
-                expect(cn.to_scholarsphere_creator).to eq ({ psu_id: 'abc123', orcid: 'orcidid123', display_name: 'last' })
+              context 'when the contributor is active' do
+                before do
+                  allow(user).to receive(:is_active).and_return true
+                end
+               
+                it 'returns a hash with the full name, WebAccess ID, and ORCID ID of the contributor' do
+                  expect(cn.to_scholarsphere_creator).to eq ({ psu_id: 'abc123', orcid: 'orcidid123', display_name: 'last' })
+                end
+              end
+
+              context 'when the contributor is not active' do
+                before do
+                  allow(user).to receive(:is_active).and_return false
+                end
+
+                it 'returns a hash with the full name and ORCID ID of the contributor' do
+                  expect(cn.to_scholarsphere_creator).to eq ({ orcid: 'orcidid123', display_name: 'last' })
+                end
               end
             end
           end
@@ -387,16 +500,48 @@ describe ContributorName, type: :model do
             context 'when the contributor has a last name' do
               let(:ln) { 'last' }
 
-              it 'returns a hash with the full name and WebAccess ID of the contributor' do
-                expect(cn.to_scholarsphere_creator).to eq({ psu_id: 'abc123', display_name: 'first middle last' })
+              context 'when the contributor is active' do
+                before do
+                  allow(user).to receive(:is_active).and_return true
+                end
+               
+                it 'returns a hash with the full name and WebAccess ID of the contributor' do
+                  expect(cn.to_scholarsphere_creator).to eq({ psu_id: 'abc123', display_name: 'first middle last' })
+                end
+              end
+
+              context 'when the contributor is not active' do
+                before do
+                  allow(user).to receive(:is_active).and_return false
+                end
+
+                it 'returns a hash with the full name of the contributor' do
+                  expect(cn.to_scholarsphere_creator).to eq({ display_name: 'first middle last' })
+                end
               end
             end
 
             context 'when the contributor has no last name' do
               let(:ln) { '' }
 
-              it 'returns a hash with the full name and WebAccess ID of the contributor' do
-                expect(cn.to_scholarsphere_creator).to eq({ psu_id: 'abc123', display_name: 'first middle' })
+              context 'when the contributor is active' do
+                before do
+                  allow(user).to receive(:is_active).and_return true
+                end
+               
+                it 'returns a hash with the full name and WebAccess ID of the contributor' do
+                  expect(cn.to_scholarsphere_creator).to eq({ psu_id: 'abc123', display_name: 'first middle' })
+                end
+              end
+
+              context 'when the contributor is not active' do
+                before do
+                  allow(user).to receive(:is_active).and_return false
+                end
+
+                it 'returns a hash with the full name of the contributor' do
+                  expect(cn.to_scholarsphere_creator).to eq({ display_name: 'first middle' })
+                end
               end
             end
           end
@@ -407,16 +552,48 @@ describe ContributorName, type: :model do
             context 'when the contributor has a last name' do
               let(:ln) { 'last' }
 
-              it 'returns a hash with the full name and WebAccess ID of the contributor' do
-                expect(cn.to_scholarsphere_creator).to eq({ psu_id: 'abc123', display_name: 'first last' })
+              context 'when the contributor is active' do
+                before do
+                  allow(user).to receive(:is_active).and_return true
+                end
+               
+                it 'returns a hash with the full name and WebAccess ID of the contributor' do
+                  expect(cn.to_scholarsphere_creator).to eq({ psu_id: 'abc123', display_name: 'first last' })
+                end
+              end
+
+              context 'when the contributor is not active' do
+                before do
+                  allow(user).to receive(:is_active).and_return false
+                end
+
+                it 'returns a hash with the full name of the contributor' do
+                  expect(cn.to_scholarsphere_creator).to eq({ display_name: 'first last' })
+                end
               end
             end
 
             context 'when the contributor has no last name' do
               let(:ln) { '' }
 
-              it 'returns a hash with the full name and WebAccess ID of the contributor' do
-                expect(cn.to_scholarsphere_creator).to eq({ psu_id: 'abc123', display_name: 'first' })
+              context 'when the contributor is active' do
+                before do
+                  allow(user).to receive(:is_active).and_return true
+                end
+               
+                it 'returns a hash with the full name and WebAccess ID of the contributor' do
+                  expect(cn.to_scholarsphere_creator).to eq({ psu_id: 'abc123', display_name: 'first' })
+                end
+              end
+
+              context 'when the contributor is not active' do
+                before do
+                  allow(user).to receive(:is_active).and_return false
+                end
+
+                it 'returns a hash with the full name of the contributor' do
+                  expect(cn.to_scholarsphere_creator).to eq({ display_name: 'first' })
+                end
               end
             end
           end
@@ -431,16 +608,48 @@ describe ContributorName, type: :model do
             context 'when the contributor has a last name' do
               let(:ln) { 'last' }
 
-              it 'returns a hash with the full name and WebAccess ID of the contributor' do
-                expect(cn.to_scholarsphere_creator).to eq ({ psu_id: 'abc123', display_name: 'middle last' })
+              context 'when the contributor is active' do
+                before do
+                  allow(user).to receive(:is_active).and_return true
+                end
+               
+                it 'returns a hash with the full name and WebAccess ID of the contributor' do
+                  expect(cn.to_scholarsphere_creator).to eq ({ psu_id: 'abc123', display_name: 'middle last' })
+                end
+              end
+
+              context 'when the contributor is not active' do
+                before do
+                  allow(user).to receive(:is_active).and_return false
+                end
+
+                it 'returns a hash with the full name of the contributor' do
+                  expect(cn.to_scholarsphere_creator).to eq ({ display_name: 'middle last' })
+                end
               end
             end
 
             context 'when the contributor has no last name' do
               let(:ln) { '' }
 
-              it 'returns a hash with the full name and WebAccess ID of the contributor' do
-                expect(cn.to_scholarsphere_creator).to eq ({ psu_id: 'abc123', display_name: 'middle' })
+              context 'when the contributor is active' do
+                before do
+                  allow(user).to receive(:is_active).and_return true
+                end
+               
+                it 'returns a hash with the full name and WebAccess ID of the contributor' do
+                  expect(cn.to_scholarsphere_creator).to eq ({ psu_id: 'abc123', display_name: 'middle' })
+                end
+              end
+
+              context 'when the contributor is not active' do
+                before do
+                  allow(user).to receive(:is_active).and_return false
+                end
+
+                it 'returns a hash with the full name of the contributor' do
+                  expect(cn.to_scholarsphere_creator).to eq ({ display_name: 'middle' })
+                end
               end
             end
           end
@@ -451,8 +660,24 @@ describe ContributorName, type: :model do
             context 'when the contributor has a last name' do
               let(:ln) { 'last' }
 
-              it 'returns a hash with the full name and WebAccess ID of the contributor' do
-                expect(cn.to_scholarsphere_creator).to eq ({ psu_id: 'abc123', display_name: 'last' })
+              context 'when the contributor is active' do
+                before do
+                  allow(user).to receive(:is_active).and_return true
+                end
+               
+                it 'returns a hash with the full name and WebAccess ID of the contributor' do
+                  expect(cn.to_scholarsphere_creator).to eq ({ psu_id: 'abc123', display_name: 'last' })
+                end
+              end
+
+              context 'when the contributor is not active' do
+                before do
+                  allow(user).to receive(:is_active).and_return false
+                end
+
+                it 'returns a hash with the full name of the contributor' do
+                  expect(cn.to_scholarsphere_creator).to eq ({ display_name: 'last' })
+                end
               end
             end
           end

--- a/spec/component/models/scholarsphere_work_deposit_spec.rb
+++ b/spec/component/models/scholarsphere_work_deposit_spec.rb
@@ -398,7 +398,7 @@ describe ScholarsphereFileUpload, type: :model do
                         last_name: 'Researcher',
                         position: 1,
                         user: user) }
-    let!(:user) { create(:user, webaccess_id: 'abc123', orcid_identifier: 'https://orcid.org/orcid-id-456') }
+    let!(:user) { create(:user, :with_psu_identity, webaccess_id: 'abc123', orcid_identifier: 'https://orcid.org/orcid-id-456') }
     let(:dep) {
       ScholarsphereWorkDeposit.new(
         title: 'test title',

--- a/spec/integration/user_profile_spec.rb
+++ b/spec/integration/user_profile_spec.rb
@@ -47,7 +47,7 @@ describe UserProfile do
         expect(u.psu_identity.data['givenName']).to eq 'Daniel'
         expect(u.psu_identity.data['middleName']).to eq 'M'
         expect(u.psu_identity.data['familyName']).to eq 'Coughlin'
-        expect(u.psu_identity.data['affiliation']).to eq ['FACULTY']
+        expect(u.psu_identity.data['affiliation']).to eq ['FACULTY', 'MEMBER']
         expect(u.psu_identity.data['userid']).to eq 'dmc186'
         expect(u.psu_identity_updated_at).not_to be_nil
       end


### PR DESCRIPTION
Delegates is_active to user in contributor_names.  Uses this to determine whether or not to include a webaccess_id in the to_scholarsphere metadata. 

closes #737 