### PR TITLE
Fix ai download

### DIFF
--- a/app/jobs/publication_download_job.rb
+++ b/app/jobs/publication_download_job.rb
@@ -26,6 +26,9 @@ class PublicationDownloadJob < ApplicationJob
           Rails.logger.error "#{response.code}: #{response.message}"
           file.update(downloaded: false)
         end
+      rescue StandardError => e
+        Rails.logger.error e.message
+        file.update(downloaded: false)
       end
     end
   end

--- a/app/jobs/publication_download_job.rb
+++ b/app/jobs/publication_download_job.rb
@@ -26,10 +26,10 @@ class PublicationDownloadJob < ApplicationJob
           Rails.logger.error "#{response.code}: #{response.message}"
           file.update(downloaded: false)
         end
-      rescue StandardError => e
-        Rails.logger.error e.message
-        file.update(downloaded: false)
       end
     end
+  rescue StandardError => e
+    Rails.logger.error e.message
+    file.update(downloaded: false)
   end
 end

--- a/app/models/activity_insight_oa_file.rb
+++ b/app/models/activity_insight_oa_file.rb
@@ -32,7 +32,7 @@ class ActivityInsightOAFile < ApplicationRecord
   end
 
   def download_uri
-    "https://#{S3_AUTHORIZER_HOST_NAME}/api/v1/#{URI::Parser.new.escape(location)}"
+    "https://#{S3_AUTHORIZER_HOST_NAME}/api/v1/#{URI::DEFAULT_PARSER.escape(location)}"
   end
 
   ALLOWED_VERSIONS = [I18n.t('file_versions.accepted_version'),

--- a/app/models/activity_insight_oa_file.rb
+++ b/app/models/activity_insight_oa_file.rb
@@ -32,7 +32,7 @@ class ActivityInsightOAFile < ApplicationRecord
   end
 
   def download_uri
-    "https://#{S3_AUTHORIZER_HOST_NAME}/api/v1/#{location}"
+    "https://#{S3_AUTHORIZER_HOST_NAME}/api/v1/#{URI::Parser.new.escape(location)}"
   end
 
   ALLOWED_VERSIONS = [I18n.t('file_versions.accepted_version'),

--- a/spec/component/jobs/publication_download_job_spec.rb
+++ b/spec/component/jobs/publication_download_job_spec.rb
@@ -39,6 +39,21 @@ describe PublicationDownloadJob, type: :job do
       end
     end
 
+    context 'when an error is raised' do
+      before do
+        allow(Net::HTTP).to receive(:start).and_raise(Errno::ETIMEDOUT)
+      end
+
+      it 'does not store the file' do
+        expect(Rails.logger).to receive(:error).with('Operation timed out')
+        ai_oa_file.update(downloaded: true)
+        job.perform_now(ai_oa_file.id)
+        expect(ai_oa_file.reload.stored_file_path).to be_nil
+        expect(File.exists?(file_path)).to be false
+        expect(ai_oa_file.reload.downloaded).to be false
+      end
+    end
+
     context 'when response code is not "200"' do
       let!(:ai_oa_file) { create(:activity_insight_oa_file, publication: publication, version: 'acceptedVersion', location: 'fakeperson/intellcont/test_file-1.pdf') }
 


### PR DESCRIPTION
The escaping seemed to work for me.  There were 344 `ActivityInsightOAFiles` ready for download on my local machine.  After running this with the escaping implemented, 343 successfully downloaded and one failed due to a timeout error.  I added some error handling to deal with these.  I went with rescuing `StandardError` since that seems to be the preferred way to cover all of the potential errors with Net::HTTP.