### PR TITLE
fix migration names

### DIFF
--- a/db/migrate/20191108165421_add_open_access_url_to_publications.rb
+++ b/db/migrate/20191108165421_add_open_access_url_to_publications.rb
@@ -1,4 +1,4 @@
-class AddOpenAccessUrlToPublications < ActiveRecord::Migration[5.2]
+class AddOpenAccessURLToPublications < ActiveRecord::Migration[5.2]
   def change
     add_column :publications, :open_access_url, :text
   end

--- a/db/migrate/20191115202327_add_user_submitted_open_access_url_to_publications.rb
+++ b/db/migrate/20191115202327_add_user_submitted_open_access_url_to_publications.rb
@@ -1,4 +1,4 @@
-class AddUserSubmittedOpenAccessUrlToPublications < ActiveRecord::Migration[5.2]
+class AddUserSubmittedOpenAccessURLToPublications < ActiveRecord::Migration[5.2]
   def change
     add_column :publications, :user_submitted_open_access_url, :text
   end

--- a/db/migrate/20210204222315_add_scholarsphere_open_access_url_to_publications.rb
+++ b/db/migrate/20210204222315_add_scholarsphere_open_access_url_to_publications.rb
@@ -1,4 +1,4 @@
-class AddScholarsphereOpenAccessUrlToPublications < ActiveRecord::Migration[5.2]
+class AddScholarsphereOpenAccessURLToPublications < ActiveRecord::Migration[5.2]
   def change
     add_column :publications, :scholarsphere_open_access_url, :text
   end


### PR DESCRIPTION
The changes we made to the migration scripts weren't idempotent, and warned about being destructive. I want to revert to using `rails db:migrate` to keep in line with our other rails applications, and to have an idempotent workflow. The issue seems to be with URL inflection, so it seems innocuous enough 