### PR TITLE
paramterize CI_UTILS_IMAGE_TAG

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ orbs:
 jobs:
   release:
     docker:
-      - image: harbor.k8s.libraries.psu.edu/library/ci-utils:v4.0.0
+      - image: harbor.k8s.libraries.psu.edu/library/ci-utils:$CI_UTILS_IMAGE_TAG
     environment:
       REGISTRY_HOST: harbor.k8s.libraries.psu.edu
       REGISTRY_REPO: library/researcher-metadata


### PR DESCRIPTION
makes CI_UTILS_IMAGE_TAG a circleci variable that we can override at the org, or repo setting