### PR TITLE
User file association

### DIFF
--- a/app/assets/stylesheets/application/screen.scss.erb
+++ b/app/assets/stylesheets/application/screen.scss.erb
@@ -120,8 +120,3 @@ footer .list-unstyled img {
 .notice {
   margin-bottom: 0;
 }
-
-.table-scrollable{
-  overflow-y:scroll;
-  display:block;
-}

--- a/app/assets/stylesheets/application/screen.scss.erb
+++ b/app/assets/stylesheets/application/screen.scss.erb
@@ -110,6 +110,7 @@ footer .list-unstyled img {
 
 .file-name {
   max-width: 300px;
+  overflow-wrap: break-word;
 }
 
 .alert {

--- a/app/components/activity_insight_oa_dashboard_component.html.erb
+++ b/app/components/activity_insight_oa_dashboard_component.html.erb
@@ -52,4 +52,22 @@
       <div class='card-body'><%= i18n('permissions_curation_description') %></div>
     </div>
   <% end %>
+  <br>
+  <% if ready_for_metadata_review_count.nonzero? %>
+    <%= link_to activity_insight_oa_workflow_metadata_review_path, class: 'card-link' do %>
+      <div class='card' id='metadata-check-card'>
+        <div class='card-header'><strong><%= i18n('metadata_curation_title') %></strong>
+          <span class='float-right text-large'><strong><%= ready_for_metadata_review_count %></strong></span>
+        </div>
+        <div class='card-body'><%= i18n('metadata_curation_description') %></div>
+      </div>
+    <% end %>
+  <% else %>
+    <div class='card text-muted' id='metadata-check-card'>
+      <div class='card-header'><strong><%= i18n('metadata_curation_title') %></strong>
+        <span class='float-right text-large'>0</strong></span>
+      </div>
+      <div class='card-body'><%= i18n('metadata_curation_description') %></div>
+    </div>
+  <% end %>
 </div>

--- a/app/components/activity_insight_oa_dashboard_component.rb
+++ b/app/components/activity_insight_oa_dashboard_component.rb
@@ -13,6 +13,10 @@ class ActivityInsightOADashboardComponent < ViewComponent::Base
     Publication.permissions_check_failed.count
   end
 
+  def ready_for_metadata_review_count
+    Publication.ready_for_metadata_review.count
+  end
+
   def i18n(key, **options)
     I18n.t("view_component.#{self.class.name.underscore}.#{key}", **options)
   end

--- a/app/controllers/activity_insight_oa_workflow/metadata_curation_controller.rb
+++ b/app/controllers/activity_insight_oa_workflow/metadata_curation_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ActivityInsightOAWorkflow::MetadataCurationController < ActivityInsightOAWorkflowController
+  def index
+    @publications = Publication.ready_for_metadata_review
+  end
+end

--- a/app/importers/activity_insight_importer.rb
+++ b/app/importers/activity_insight_importer.rb
@@ -207,7 +207,7 @@ class ActivityInsightImporter
             aif = pub_record.activity_insight_oa_files.find_by(location: activity_insight_file_location)
 
             if aif.blank?
-              file = ActivityInsightOAFile.create(location: activity_insight_file_location)
+              file = ActivityInsightOAFile.create(location: activity_insight_file_location, user: u)
               pub_record.activity_insight_oa_files << file
               pub_record.save!
               unless pub_record.doi_verified == true

--- a/app/models/activity_insight_oa_file.rb
+++ b/app/models/activity_insight_oa_file.rb
@@ -3,6 +3,7 @@
 class ActivityInsightOAFile < ApplicationRecord
   belongs_to :publication,
              inverse_of: :activity_insight_oa_files
+  belongs_to :user
 
   mount_uploader :file_download_location, ActivityInsightFileUploader
 

--- a/app/models/activity_insight_oa_file.rb
+++ b/app/models/activity_insight_oa_file.rb
@@ -63,7 +63,7 @@ class ActivityInsightOAFile < ApplicationRecord
         end
       end
       field(:downloaded)
-      field(:download_location_value) { label 'File download'}
+      field(:download_location_value) { label 'File download' }
     end
 
     list do
@@ -74,7 +74,7 @@ class ActivityInsightOAFile < ApplicationRecord
       field(:updated_at)
       field(:publication)
       field(:downloaded)
-      field(:download_location_value) { label 'File download'}
+      field(:download_location_value) { label 'File download' }
     end
 
     edit do

--- a/app/models/activity_insight_oa_file.rb
+++ b/app/models/activity_insight_oa_file.rb
@@ -3,7 +3,12 @@
 class ActivityInsightOAFile < ApplicationRecord
   belongs_to :publication,
              inverse_of: :activity_insight_oa_files
-  belongs_to :user
+
+  # TODO:  We ultimately don't want this association to be optional, but
+  # the data will be missing for records that already exist in production,
+  # and we don't want to break anything. Once we have populated all of the
+  # existing production records, then we should make this required.
+  belongs_to :user, optional: true
 
   mount_uploader :file_download_location, ActivityInsightFileUploader
 
@@ -55,6 +60,7 @@ class ActivityInsightOAFile < ApplicationRecord
     show do
       field(:location)
       field(:version)
+      field(:user)
       field(:created_at)
       field(:updated_at)
       field(:publication)
@@ -74,6 +80,7 @@ class ActivityInsightOAFile < ApplicationRecord
       field(:created_at)
       field(:updated_at)
       field(:publication)
+      field(:user)
       field(:downloaded)
       field(:download_location_value) { label 'File download' }
     end

--- a/app/models/activity_insight_oa_file.rb
+++ b/app/models/activity_insight_oa_file.rb
@@ -64,13 +64,12 @@ class ActivityInsightOAFile < ApplicationRecord
       field(:created_at)
       field(:updated_at)
       field(:publication)
-      field 'File' do
+      field 'File download' do
         formatted_value do
-          bindings[:view].link_to("Download #{bindings[:object].download_filename}", Rails.application.routes.url_helpers.activity_insight_oa_workflow_file_download_path(bindings[:object].id))
+          bindings[:view].link_to(bindings[:object].download_location_value.to_s, Rails.application.routes.url_helpers.activity_insight_oa_workflow_file_download_path(bindings[:object].id))
         end
       end
       field(:downloaded)
-      field(:download_location_value) { label 'File download' }
     end
 
     list do

--- a/app/models/activity_insight_oa_file.rb
+++ b/app/models/activity_insight_oa_file.rb
@@ -46,6 +46,10 @@ class ActivityInsightOAFile < ApplicationRecord
     'Wrong Version'
   end
 
+  def download_location_value
+    read_attribute(:file_download_location)
+  end
+
   rails_admin do
     show do
       field(:location)
@@ -58,6 +62,8 @@ class ActivityInsightOAFile < ApplicationRecord
           bindings[:view].link_to("Download #{bindings[:object].download_filename}", Rails.application.routes.url_helpers.activity_insight_oa_workflow_file_download_path(bindings[:object].id))
         end
       end
+      field(:downloaded)
+      field(:download_location_value) { label 'File download'}
     end
 
     list do
@@ -67,6 +73,8 @@ class ActivityInsightOAFile < ApplicationRecord
       field(:created_at)
       field(:updated_at)
       field(:publication)
+      field(:downloaded)
+      field(:download_location_value) { label 'File download'}
     end
 
     edit do

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -167,6 +167,11 @@ class Publication < ApplicationRecord
         %{licence IS NULL OR preferred_version IS NULL OR (embargo_date IS NULL AND checked_for_embargo_date IS DISTINCT FROM TRUE) OR (set_statement IS NULL AND checked_for_set_statement IS DISTINCT FROM TRUE)}
       )
   }
+  scope :ready_for_metadata_review, -> { 
+    activity_insight_oa_publication
+      .where.not(preferred_version: nil)
+      .where(%{EXISTS (SELECT id FROM activity_insight_oa_files WHERE activity_insight_oa_files.publication_id = publications.id AND publications.preferred_version = activity_insight_oa_files.version AND activity_insight_oa_files.downloaded IS TRUE AND activity_insight_oa_files.file_download_location IS NOT NULL)})
+  }
 
   accepts_nested_attributes_for :authorships, allow_destroy: true
   accepts_nested_attributes_for :contributor_names, allow_destroy: true

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -337,6 +337,7 @@ class Publication < ApplicationRecord
           )
         end
       end
+      field(:activity_insight_oa_files)
       field(:abstract)
       field(:authors_et_al) { label 'Et al authors?' }
       field(:published_on)

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -167,10 +167,22 @@ class Publication < ApplicationRecord
         %{licence IS NULL OR preferred_version IS NULL OR (embargo_date IS NULL AND checked_for_embargo_date IS DISTINCT FROM TRUE) OR (set_statement IS NULL AND checked_for_set_statement IS DISTINCT FROM TRUE)}
       )
   }
-  scope :ready_for_metadata_review, -> { 
+  scope :ready_for_metadata_review, -> {
     activity_insight_oa_publication
-      .where.not(preferred_version: nil)
-      .where(%{EXISTS (SELECT id FROM activity_insight_oa_files WHERE activity_insight_oa_files.publication_id = publications.id AND publications.preferred_version = activity_insight_oa_files.version AND activity_insight_oa_files.downloaded IS TRUE AND activity_insight_oa_files.file_download_location IS NOT NULL)})
+      .where(
+        <<-SQL.squish
+          EXISTS (
+            SELECT id FROM activity_insight_oa_files
+            WHERE activity_insight_oa_files.publication_id = publications.id
+              AND publications.preferred_version = activity_insight_oa_files.version
+              AND licence IS NOT NULL
+              AND (set_statement IS NOT NULL OR checked_for_set_statement IS TRUE)
+              AND (embargo_date IS NOT NULL OR checked_for_embargo_date IS TRUE)
+              AND activity_insight_oa_files.downloaded IS TRUE
+              AND activity_insight_oa_files.file_download_location IS NOT NULL
+          )
+        SQL
+      )
   }
 
   accepts_nested_attributes_for :authorships, allow_destroy: true

--- a/app/models/scholarsphere_work_deposit.rb
+++ b/app/models/scholarsphere_work_deposit.rb
@@ -8,17 +8,7 @@ class ScholarsphereWorkDeposit < ApplicationRecord
   end
 
   def self.rights
-    %w{
-      https://creativecommons.org/licenses/by/4.0/
-      https://creativecommons.org/licenses/by-sa/4.0/
-      https://creativecommons.org/licenses/by-nc/4.0/
-      https://creativecommons.org/licenses/by-nd/4.0/
-      https://creativecommons.org/licenses/by-nc-nd/4.0/
-      https://creativecommons.org/licenses/by-nc-sa/4.0/
-      http://creativecommons.org/publicdomain/mark/1.0/
-      http://creativecommons.org/publicdomain/zero/1.0/
-      https://rightsstatements.org/page/InC/1.0/
-    }
+    rights_options.pluck(1)
   end
 
   def self.rights_options

--- a/app/views/activity_insight_oa_workflow/doi_verification/index.html.erb
+++ b/app/views/activity_insight_oa_workflow/doi_verification/index.html.erb
@@ -1,7 +1,6 @@
 <div class="container pt-4 pb-5">
   <%= link_to '<< Back', activity_insight_oa_workflow_path %>
   <h1 class="pb-3 pt-2">Publications Requiring DOI Verification</h1>
-  <div class='card'>
   <table class="table">
     <thead class='card-header'>
       <tr>
@@ -31,5 +30,4 @@
       <% end %>
     </tbody>
   </table>
-  </div>
 </div>

--- a/app/views/activity_insight_oa_workflow/file_version_curation/index.html.erb
+++ b/app/views/activity_insight_oa_workflow/file_version_curation/index.html.erb
@@ -1,7 +1,6 @@
 <div class="container pt-4 pb-5">
   <%= link_to '<< Back', activity_insight_oa_workflow_path %>
   <h1 class="pb-3 pt-2">Publications Requiring File Version Review</h1>
-  <div class='card'>
   <table class="table">
     <thead class='card-header'>
       <tr>
@@ -40,5 +39,4 @@
       <% end %>
     </tbody>
   </table>
-  </div>
 </div>

--- a/app/views/activity_insight_oa_workflow/metadata_curation/index.html.erb
+++ b/app/views/activity_insight_oa_workflow/metadata_curation/index.html.erb
@@ -1,0 +1,22 @@
+<div class="container pt-4 pb-5">
+  <%= link_to '<< Back', activity_insight_oa_workflow_path %>
+  <h1 class="pb-3 pt-2">Publications Ready for Metadata Review</h1>
+  <div class='card'>
+  <table class="table">
+    <thead class='card-header'>
+      <tr>
+        <th>Title</th>
+      </tr>
+    </thead>
+    <tbody class='card-body'>
+      <% @publications.each do |p| %>
+        <tr id="<%= dom_id(p) %>">
+          <td><%= link_to p.title.truncate(45),
+                  rails_admin.edit_path(model_name: :publication, id: p.id),
+                  target: '_blank' %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+  </div>
+</div>

--- a/app/views/activity_insight_oa_workflow/metadata_curation/index.html.erb
+++ b/app/views/activity_insight_oa_workflow/metadata_curation/index.html.erb
@@ -1,7 +1,6 @@
 <div class="container pt-4 pb-5">
   <%= link_to '<< Back', activity_insight_oa_workflow_path %>
   <h1 class="pb-3 pt-2">Publications Ready for Metadata Review</h1>
-  <div class='card'>
   <table class="table">
     <thead class='card-header'>
       <tr>
@@ -18,5 +17,4 @@
       <% end %>
     </tbody>
   </table>
-  </div>
 </div>

--- a/app/views/activity_insight_oa_workflow/permissions_curation/index.html.erb
+++ b/app/views/activity_insight_oa_workflow/permissions_curation/index.html.erb
@@ -1,7 +1,7 @@
 <div class="container pt-4 pb-5">
   <%= link_to '<< Back', activity_insight_oa_workflow_path %>
   <h1 class="pb-3 pt-2">Publications Requiring Permissions Review</h1>
-  <table class="table table-scrollable">
+  <table class="table">
     <thead class='card-header'>
       <tr>
         <th>Title</th>

--- a/app/views/activity_insight_oa_workflow/permissions_curation/index.html.erb
+++ b/app/views/activity_insight_oa_workflow/permissions_curation/index.html.erb
@@ -1,7 +1,6 @@
 <div class="container pt-4 pb-5">
   <%= link_to '<< Back', activity_insight_oa_workflow_path %>
   <h1 class="pb-3 pt-2">Publications Requiring Permissions Review</h1>
-  <div class='card'>
   <table class="table table-scrollable">
     <thead class='card-header'>
       <tr>
@@ -39,5 +38,4 @@
       <% end %>
     </tbody>
   </table>
-  </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -211,6 +211,8 @@ en:
       file_version_curation_description: Publications that still have an unknown file version and no correct version after automated file version checking.
       permissions_curation_title: Review Permissions
       permissions_curation_description: Publications that require manual permissions curation.
+      metadata_curation_title: Review Publication Metadata
+      metadata_curation_description: Publications that have a file which can be deposited and that are ready for a final metadata check prior to submission to ScholarSphere.
 
   helpers:
     submit:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,7 @@ Rails.application.routes.draw do
     get '/file_version_review' => 'file_version_curation#index'
     get '/permissions_review' => 'permissions_curation#index'
     get '/files/:activity_insight_oa_file_id/download' => 'files#download', as: :file_download
+    get '/metadata_review' => 'metadata_curation#index'
   end
 
   root to: 'public#home'

--- a/db/migrate/20230824203549_add_user_id_to_activity_insight_oa_files.rb
+++ b/db/migrate/20230824203549_add_user_id_to_activity_insight_oa_files.rb
@@ -1,0 +1,11 @@
+class AddUserIdToActivityInsightOAFiles < ActiveRecord::Migration[6.1]
+  def change
+    add_column :activity_insight_oa_files, :user_id, :integer
+    add_index :activity_insight_oa_files, :user_id
+    add_foreign_key(
+      :activity_insight_oa_files,
+      :users,
+      name: :activity_insight_oa_files_user_id_fk
+    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_08_17_202119) do
+ActiveRecord::Schema.define(version: 2023_08_24_203549) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -52,7 +52,9 @@ ActiveRecord::Schema.define(version: 2023_08_17_202119) do
     t.string "version"
     t.string "file_download_location"
     t.boolean "downloaded"
+    t.integer "user_id"
     t.index ["publication_id"], name: "index_activity_insight_oa_files_on_publication_id"
+    t.index ["user_id"], name: "index_activity_insight_oa_files_on_user_id"
   end
 
   create_table "api_tokens", force: :cascade do |t|
@@ -667,6 +669,7 @@ ActiveRecord::Schema.define(version: 2023_08_17_202119) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "activity_insight_oa_files", "publications", name: "activity_insight_oa_files_publication_id_fk", on_delete: :cascade
+  add_foreign_key "activity_insight_oa_files", "users", name: "activity_insight_oa_files_user_id_fk"
   add_foreign_key "authorships", "publications", on_delete: :cascade
   add_foreign_key "authorships", "users", on_delete: :cascade
   add_foreign_key "committee_memberships", "etds", on_delete: :cascade

--- a/spec/component/components/activity_insight_oa_dashboard_component_spec.rb
+++ b/spec/component/components/activity_insight_oa_dashboard_component_spec.rb
@@ -90,4 +90,41 @@ RSpec.describe ActivityInsightOADashboardComponent, type: :component do
       expect(rendered_component).to have_link(href: '/activity_insight_oa_workflow/permissions_review')
     end
   end
+
+  context 'when no publications are ready for final metadata review' do
+    let(:pub1) { create(:publication) }
+    let(:pub2) { create(:publication) }
+
+    it 'renders a muted card with no link' do
+      render_inline(described_class.new)
+      expect(page.find_by_id('metadata-check-card').to_json).to include('text-muted')
+      expect(page.find_by_id('metadata-check-card').text).to include('0')
+      expect(rendered_component).not_to have_link(
+        href: Rails.application.routes.url_helpers.activity_insight_oa_workflow_metadata_review_path
+      )
+    end
+  end
+
+  context 'when publications are ready for final metadata review' do
+    let(:pub1) { create(:publication, preferred_version: 'acceptedVersion') }
+    let(:pub2) { create(:publication) }
+    let!(:aif) { 
+      create(
+        :activity_insight_oa_file,
+        publication: pub1,
+        version: 'acceptedVersion',
+        downloaded: true,
+        file_download_location: fixture_file_open('test_file.pdf')
+      )
+    }
+
+    it 'renders the metadata review card with a link and the number of publications in the corner' do
+      render_inline(described_class.new)
+      expect(page.find_by_id('metadata-check-card').to_json).not_to include('text-muted')
+      expect(page.find_by_id('metadata-check-card').text).to include('1')
+      expect(rendered_component).to have_link(
+        href: Rails.application.routes.url_helpers.activity_insight_oa_workflow_metadata_review_path
+      )
+    end
+  end
 end

--- a/spec/component/components/activity_insight_oa_dashboard_component_spec.rb
+++ b/spec/component/components/activity_insight_oa_dashboard_component_spec.rb
@@ -106,7 +106,15 @@ RSpec.describe ActivityInsightOADashboardComponent, type: :component do
   end
 
   context 'when publications are ready for final metadata review' do
-    let(:pub1) { create(:publication, preferred_version: 'acceptedVersion') }
+    let(:pub1) {
+      create(
+        :publication,
+        preferred_version: 'acceptedVersion',
+        licence: 'license',
+        set_statement: 'statement',
+        embargo_date: Date.current
+      )
+    }
     let(:pub2) { create(:publication) }
     let!(:aif) {
       create(

--- a/spec/component/components/activity_insight_oa_dashboard_component_spec.rb
+++ b/spec/component/components/activity_insight_oa_dashboard_component_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe ActivityInsightOADashboardComponent, type: :component do
   context 'when publications are ready for final metadata review' do
     let(:pub1) { create(:publication, preferred_version: 'acceptedVersion') }
     let(:pub2) { create(:publication) }
-    let!(:aif) { 
+    let!(:aif) {
       create(
         :activity_insight_oa_file,
         publication: pub1,

--- a/spec/component/importers/activity_insight_importer_spec.rb
+++ b/spec/component/importers/activity_insight_importer_spec.rb
@@ -4930,6 +4930,8 @@ describe ActivityInsightImporter do
       context 'when no ActivityInsightOAFile exists for publications imported with postprint/open access files' do
         it 'creates an ActivityInsightOAFile for those publications' do
           importer.call
+          u = User.find_by(webaccess_id: 'abc123')
+
           p1 = PublicationImport.find_by(source: 'Activity Insight',
                                          source_identifier: '171620739072').publication
           p3 = PublicationImport.find_by(source: 'Activity Insight',
@@ -4937,12 +4939,19 @@ describe ActivityInsightImporter do
           p4 = PublicationImport.find_by(source: 'Activity Insight',
                                          source_identifier: '171620739090').publication
 
+          f1 = p1.activity_insight_oa_files.first
+          f3 = p3.activity_insight_oa_files.first
+          f4 = p4.activity_insight_oa_files.first
+
           expect(ActivityInsightOAFile.count).to be 3
-          expect(p1.activity_insight_oa_files.first.location).to eq('abc123/intellcont/file.pdf')
+          expect(f1.location).to eq('abc123/intellcont/file.pdf')
+          expect(f1.user).to eq u
           expect(p1.oa_workflow_state).to eq('automatic DOI verification pending')
-          expect(p3.activity_insight_oa_files.first.location).to eq('abc123/intellcont/file-5.pdf')
+          expect(f3.location).to eq('abc123/intellcont/file-5.pdf')
+          expect(f3.user).to eq u
           expect(p3.oa_workflow_state).to eq('automatic DOI verification pending')
-          expect(p4.activity_insight_oa_files.first.location).to eq('abc123/intellcont/file-6.pdf')
+          expect(f4.location).to eq('abc123/intellcont/file-6.pdf')
+          expect(f4.user).to eq u
           expect(p4.oa_workflow_state).to eq('automatic DOI verification pending')
         end
 

--- a/spec/component/models/activity_insight_oa_file_spec.rb
+++ b/spec/component/models/activity_insight_oa_file_spec.rb
@@ -12,13 +12,20 @@ RSpec.describe ActivityInsightOAFile, type: :model do
   it { is_expected.to have_db_column(:version).of_type(:string) }
   it { is_expected.to have_db_column(:file_download_location).of_type(:string) }
   it { is_expected.to have_db_column(:downloaded).of_type(:boolean) }
+  it { is_expected.to have_db_column(:publication_id).of_type(:integer) }
+  it { is_expected.to have_db_column(:user_id).of_type(:integer) }
+
   it { is_expected.to have_db_foreign_key(:publication_id) }
+  it { is_expected.to have_db_foreign_key(:user_id) }
+
   it { is_expected.to have_db_index :publication_id }
+  it { is_expected.to have_db_index :user_id }
 
   it_behaves_like 'an application record'
 
   describe 'associations' do
     it { is_expected.to belong_to(:publication).inverse_of(:activity_insight_oa_files) }
+    it { is_expected.to belong_to(:user) }
   end
 
   describe '#file_download_location' do

--- a/spec/component/models/activity_insight_oa_file_spec.rb
+++ b/spec/component/models/activity_insight_oa_file_spec.rb
@@ -124,8 +124,9 @@ RSpec.describe ActivityInsightOAFile, type: :model do
   end
 
   describe '#download_location_value' do
-    let!(:file) { create :activity_insight_oa_file, file_download_location: fixture_file_open('test_file.pdf') }
-    it "returns the value stored in the file_download_location column" do
+    let!(:file) { create(:activity_insight_oa_file, file_download_location: fixture_file_open('test_file.pdf')) }
+
+    it 'returns the value stored in the file_download_location column' do
       expect(file.download_location_value).to eq 'test_file.pdf'
     end
   end

--- a/spec/component/models/activity_insight_oa_file_spec.rb
+++ b/spec/component/models/activity_insight_oa_file_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe ActivityInsightOAFile, type: :model do
 
   describe 'associations' do
     it { is_expected.to belong_to(:publication).inverse_of(:activity_insight_oa_files) }
-    it { is_expected.to belong_to(:user) }
+    it { is_expected.to belong_to(:user).optional }
   end
 
   describe '#file_download_location' do

--- a/spec/component/models/activity_insight_oa_file_spec.rb
+++ b/spec/component/models/activity_insight_oa_file_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe ActivityInsightOAFile, type: :model do
     it { is_expected.to belong_to(:publication).inverse_of(:activity_insight_oa_files) }
   end
 
-  describe '#file' do
+  describe '#file_download_location' do
     it 'mounts an ActivityInsightFileUploader' do
       expect(subject.file_download_location).to be_a(ActivityInsightFileUploader)
     end
@@ -120,6 +120,13 @@ RSpec.describe ActivityInsightOAFile, type: :model do
       it 'returns "Wrong Version"' do
         expect(file.version_status_display).to eq 'Wrong Version'
       end
+    end
+  end
+
+  describe '#download_location_value' do
+    let!(:file) { create :activity_insight_oa_file, file_download_location: fixture_file_open('test_file.pdf') }
+    it "returns the value stored in the file_download_location column" do
+      expect(file.download_location_value).to eq 'test_file.pdf'
     end
   end
 end

--- a/spec/component/models/publication_spec.rb
+++ b/spec/component/models/publication_spec.rb
@@ -525,7 +525,7 @@ describe Publication, type: :model do
                          doi_verified: true)
     }
     let!(:pub9a) { create(:publication,
-                          title: 'pub9',
+                          title: 'pub9a',
                           licence: nil,
                           preferred_version: 'acceptedVersion',
                           set_statement: 'statement',
@@ -536,7 +536,7 @@ describe Publication, type: :model do
                           permissions_last_checked_at: DateTime.now)
     }
     let!(:pub9b) { create(:publication,
-                          title: 'pub9',
+                          title: 'pub9b',
                           licence: 'license',
                           preferred_version: nil,
                           set_statement: 'statement',
@@ -547,7 +547,7 @@ describe Publication, type: :model do
                           permissions_last_checked_at: DateTime.now)
     }
     let!(:pub9c) { create(:publication,
-                          title: 'pub9',
+                          title: 'pub9c',
                           licence: 'license',
                           preferred_version: 'acceptedVersion',
                           set_statement: nil,
@@ -558,7 +558,7 @@ describe Publication, type: :model do
                           permissions_last_checked_at: DateTime.now)
     }
     let!(:pub9d) { create(:publication,
-                          title: 'pub9',
+                          title: 'pub9d',
                           licence: 'license',
                           preferred_version: 'acceptedVersion',
                           set_statement: 'statement',
@@ -569,7 +569,7 @@ describe Publication, type: :model do
                           permissions_last_checked_at: DateTime.now)
     }
     let!(:pub9e) { create(:publication,
-                          title: 'pub9',
+                          title: 'pub9e',
                           licence: 'license',
                           preferred_version: 'acceptedVersion',
                           set_statement: 'statement',
@@ -580,7 +580,7 @@ describe Publication, type: :model do
                           permissions_last_checked_at: DateTime.now)
     }
     let!(:pub9f) { create(:publication,
-                          title: 'pub9',
+                          title: 'pub9f',
                           licence: 'license',
                           preferred_version: 'acceptedVersion',
                           set_statement: 'statement',
@@ -591,7 +591,7 @@ describe Publication, type: :model do
                           permissions_last_checked_at: DateTime.now)
     }
     let!(:pub9g) { create(:publication,
-                          title: 'pub9',
+                          title: 'pub9g',
                           licence: 'license',
                           preferred_version: 'acceptedVersion',
                           set_statement: nil,
@@ -602,7 +602,7 @@ describe Publication, type: :model do
                           permissions_last_checked_at: DateTime.now)
     }
     let!(:pub9h) { create(:publication,
-                          title: 'pub9',
+                          title: 'pub9h',
                           licence: 'license',
                           preferred_version: 'acceptedVersion',
                           set_statement: 'statement',
@@ -613,7 +613,7 @@ describe Publication, type: :model do
                           permissions_last_checked_at: DateTime.now)
     }
     let!(:pub9i) { create(:publication,
-                          title: 'pub9',
+                          title: 'pub9i',
                           licence: 'license',
                           preferred_version: 'acceptedVersion',
                           set_statement: 'statement',
@@ -624,7 +624,7 @@ describe Publication, type: :model do
                           permissions_last_checked_at: DateTime.now)
     }
     let!(:pub9j) { create(:publication,
-                          title: 'pub9',
+                          title: 'pub9j',
                           licence: 'license',
                           preferred_version: 'acceptedVersion',
                           set_statement: nil,
@@ -651,11 +651,137 @@ describe Publication, type: :model do
                           preferred_version: 'acceptedVersion',
                           doi_verified: nil)
     }
-    let!(:pub13) { create(:publication,
-                          title: 'pub13',
-                          publication_type: 'Journal Article',
-                          preferred_version: 'acceptedVersion')
+    let!(:pub13a) { create(:publication,
+                           title: 'pub13a',
+                           publication_type: 'Journal Article',
+                           licence: 'license',
+                           preferred_version: 'acceptedVersion',
+                           set_statement: 'statement',
+                           embargo_date: Date.current,
+                           checked_for_embargo_date: nil,
+                           checked_for_set_statement: nil)
     }
+    let!(:pub13b) { create(:publication,
+                           title: 'pub13b',
+                           publication_type: 'Journal Article',
+                           licence: 'license',
+                           preferred_version: 'acceptedVersion',
+                           set_statement: 'statement',
+                           embargo_date: Date.current,
+                           checked_for_embargo_date: nil,
+                           checked_for_set_statement: nil)
+    }
+    let!(:pub13c) { create(:publication,
+                           title: 'pub13c',
+                           publication_type: 'Journal Article',
+                           licence: 'license',
+                           preferred_version: nil,
+                           set_statement: 'statement',
+                           embargo_date: Date.current,
+                           checked_for_embargo_date: nil,
+                           checked_for_set_statement: nil)
+    }
+    let!(:pub13d) { create(:publication,
+                           title: 'pub13d',
+                           publication_type: 'Journal Article',
+                           licence: nil,
+                           preferred_version: 'acceptedVersion',
+                           set_statement: 'statement',
+                           embargo_date: Date.current,
+                           checked_for_embargo_date: nil,
+                           checked_for_set_statement: nil)
+    }
+    let!(:pub13e) { create(:publication,
+                           title: 'pub13e',
+                           publication_type: 'Journal Article',
+                           licence: 'license',
+                           preferred_version: 'acceptedVersion',
+                           set_statement: nil,
+                           embargo_date: Date.current,
+                           checked_for_embargo_date: nil,
+                           checked_for_set_statement: nil)
+    }
+    let!(:pub13f) { create(:publication,
+                           title: 'pub13f',
+                           publication_type: 'Journal Article',
+                           licence: 'license',
+                           preferred_version: 'acceptedVersion',
+                           set_statement: 'statement',
+                           embargo_date: nil,
+                           checked_for_embargo_date: nil,
+                           checked_for_set_statement: nil)
+    }
+    let!(:pub13g) { create(:publication,
+                           title: 'pub13g',
+                           publication_type: 'Journal Article',
+                           licence: 'license',
+                           preferred_version: 'acceptedVersion',
+                           set_statement: 'statement',
+                           embargo_date: nil,
+                           checked_for_embargo_date: true,
+                           checked_for_set_statement: nil)
+    }
+    let!(:pub13h) { create(:publication,
+                           title: 'pub13h',
+                           publication_type: 'Journal Article',
+                           licence: 'license',
+                           preferred_version: 'acceptedVersion',
+                           set_statement: nil,
+                           embargo_date: Date.current,
+                           checked_for_embargo_date: nil,
+                           checked_for_set_statement: true)
+    }
+    let!(:pub13i) { create(:publication,
+                           title: 'pub13i',
+                           publication_type: 'Journal Article',
+                           licence: 'license',
+                           preferred_version: 'acceptedVersion',
+                           set_statement: 'statement',
+                           embargo_date: Date.current,
+                           checked_for_embargo_date: nil,
+                           checked_for_set_statement: nil)
+    }
+    let!(:pub13j) { create(:publication,
+                           title: 'pub13j',
+                           publication_type: 'Journal Article',
+                           licence: 'license',
+                           preferred_version: 'acceptedVersion',
+                           set_statement: 'statement',
+                           embargo_date: Date.current,
+                           checked_for_embargo_date: nil,
+                           checked_for_set_statement: nil)
+    }
+    let!(:pub13k) { create(:publication,
+                           title: 'pub13k',
+                           publication_type: 'Journal Article',
+                           licence: 'license',
+                           preferred_version: nil,
+                           set_statement: 'statement',
+                           embargo_date: Date.current,
+                           checked_for_embargo_date: nil,
+                           checked_for_set_statement: nil)
+    }
+    let!(:pub13l) { create(:publication,
+                           title: 'pub13l',
+                           publication_type: 'Journal Article',
+                           licence: 'license',
+                           preferred_version: 'acceptedVersion',
+                           set_statement: 'statement',
+                           embargo_date: Date.current,
+                           checked_for_embargo_date: nil,
+                           checked_for_set_statement: nil)
+    }
+    let!(:pub13m) { create(:publication,
+                           title: 'pub13m',
+                           publication_type: 'Journal Article',
+                           licence: 'license',
+                           preferred_version: 'acceptedVersion',
+                           set_statement: 'statement',
+                           embargo_date: Date.current,
+                           checked_for_embargo_date: nil,
+                           checked_for_set_statement: nil)
+    }
+
     let!(:activity_insight_oa_file1) { create(:activity_insight_oa_file, publication: pub2) }
     let!(:activity_insight_oa_file2) { create(:activity_insight_oa_file, publication: pub3) }
     let!(:activity_insight_oa_file3) { create(:activity_insight_oa_file, publication: pub4) }
@@ -677,24 +803,134 @@ describe Publication, type: :model do
     let!(:activity_insight_oa_file10) { create(:activity_insight_oa_file, publication: pub11, version: 'publishedVersion') }
     let!(:activity_insight_oa_file11) { create(:activity_insight_oa_file, publication: pub4, version: 'unknown') }
     let!(:activity_insight_oa_file12) { create(:activity_insight_oa_file, publication: pub12, version: 'publishedVersion') }
-    let!(:activity_insight_oa_file13) {
+    let!(:activity_insight_oa_file13a_1) {
       create(
         :activity_insight_oa_file,
-        publication: pub13,
+        publication: pub13a,
         version: 'unknown'
       )
     }
-    let!(:activity_insight_oa_file13a) {
+    let!(:activity_insight_oa_file13a_2) {
       create(
         :activity_insight_oa_file,
-        publication: pub13,
+        publication: pub13a,
+        version: 'acceptedVersion',
+        downloaded: true,
+        file_download_location: fixture_file_open('test_file.pdf')
+      )
+    }
+    let!(:activity_insight_oa_file13b) {
+      create(
+        :activity_insight_oa_file,
+        publication: pub13b,
+        version: 'publishedVersion',
+        downloaded: true,
+        file_download_location: fixture_file_open('test_file.pdf')
+      )
+    }
+    let!(:activity_insight_oa_file13c) {
+      create(
+        :activity_insight_oa_file,
+        publication: pub13c,
+        version: 'acceptedVersion',
+        downloaded: true,
+        file_download_location: fixture_file_open('test_file.pdf')
+      )
+    }
+    let!(:activity_insight_oa_file13d) {
+      create(
+        :activity_insight_oa_file,
+        publication: pub13d,
+        version: 'acceptedVersion',
+        downloaded: true,
+        file_download_location: fixture_file_open('test_file.pdf')
+      )
+    }
+    let!(:activity_insight_oa_file13e) {
+      create(
+        :activity_insight_oa_file,
+        publication: pub13e,
+        version: 'acceptedVersion',
+        downloaded: true,
+        file_download_location: fixture_file_open('test_file.pdf')
+      )
+    }
+    let!(:activity_insight_oa_file13f) {
+      create(
+        :activity_insight_oa_file,
+        publication: pub13f,
+        version: 'acceptedVersion',
+        downloaded: true,
+        file_download_location: fixture_file_open('test_file.pdf')
+      )
+    }
+    let!(:activity_insight_oa_file13g) {
+      create(
+        :activity_insight_oa_file,
+        publication: pub13g,
+        version: 'acceptedVersion',
+        downloaded: true,
+        file_download_location: fixture_file_open('test_file.pdf')
+      )
+    }
+    let!(:activity_insight_oa_file13h) {
+      create(
+        :activity_insight_oa_file,
+        publication: pub13h,
+        version: 'acceptedVersion',
+        downloaded: true,
+        file_download_location: fixture_file_open('test_file.pdf')
+      )
+    }
+    let!(:activity_insight_oa_file13i) {
+      create(
+        :activity_insight_oa_file,
+        publication: pub13i,
+        version: 'acceptedVersion',
+        downloaded: nil,
+        file_download_location: fixture_file_open('test_file.pdf')
+      )
+    }
+    let!(:activity_insight_oa_file13j) {
+      create(
+        :activity_insight_oa_file,
+        publication: pub13j,
+        version: 'acceptedVersion',
+        downloaded: true,
+        file_download_location: nil
+      )
+    }
+    let!(:activity_insight_oa_file13k) {
+      create(
+        :activity_insight_oa_file,
+        publication: pub13k,
+        version: nil,
+        downloaded: true,
+        file_download_location: fixture_file_open('test_file.pdf')
+      )
+    }
+    let!(:activity_insight_oa_file13l) {
+      create(
+        :activity_insight_oa_file,
+        location: nil,
+        publication: pub13l,
+        version: 'acceptedVersion',
+        downloaded: true,
+        file_download_location: fixture_file_open('test_file.pdf')
+      )
+    }
+    let!(:activity_insight_oa_file13m) {
+      create(
+        :activity_insight_oa_file,
+        publication: pub13m,
         version: 'acceptedVersion',
         downloaded: true,
         file_download_location: fixture_file_open('test_file.pdf')
       )
     }
 
-    let!(:open_access_location) { create(:open_access_location, publication: pub5) }
+    let!(:open_access_location5) { create(:open_access_location, publication: pub5) }
+    let!(:open_access_location13m) { create(:open_access_location, publication: pub13m) }
 
     describe '.with_no_oa_locations' do
       it 'returns publications that do not have open access information' do
@@ -719,7 +955,18 @@ describe Publication, type: :model do
           pub10,
           pub11,
           pub12,
-          pub13
+          pub13a,
+          pub13b,
+          pub13c,
+          pub13d,
+          pub13e,
+          pub13f,
+          pub13g,
+          pub13h,
+          pub13i,
+          pub13j,
+          pub13k,
+          pub13l
         ]
       end
     end
@@ -745,7 +992,17 @@ describe Publication, type: :model do
           pub10,
           pub11,
           pub12,
-          pub13
+          pub13a,
+          pub13b,
+          pub13c,
+          pub13d,
+          pub13e,
+          pub13f,
+          pub13g,
+          pub13h,
+          pub13i,
+          pub13j,
+          pub13k
         ]
       end
     end
@@ -758,7 +1015,22 @@ describe Publication, type: :model do
 
     describe '.needs_doi_verification' do
       it 'returns activity_insight_oa_publications whose doi_verified is nil' do
-        expect(described_class.needs_doi_verification).to match_array [pub4, pub11, pub12, pub13]
+        expect(described_class.needs_doi_verification).to match_array [
+          pub4,
+          pub11,
+          pub12,
+          pub13a,
+          pub13b,
+          pub13c,
+          pub13d,
+          pub13e,
+          pub13f,
+          pub13g,
+          pub13h,
+          pub13i,
+          pub13j,
+          pub13k
+        ]
       end
     end
 
@@ -801,9 +1073,8 @@ describe Publication, type: :model do
     end
 
     describe '.ready_for_metadata_review' do
-      # TODO: Add more test cases for this query
       it 'returns activity_insight_oa_publications with a preferred version and a downloaded file that matches the preferred version' do
-        expect(described_class.ready_for_metadata_review).to match_array [pub13]
+        expect(described_class.ready_for_metadata_review).to match_array [pub13a, pub13g, pub13h]
       end
     end
   end

--- a/spec/component/models/publication_spec.rb
+++ b/spec/component/models/publication_spec.rb
@@ -651,6 +651,11 @@ describe Publication, type: :model do
                           preferred_version: 'acceptedVersion',
                           doi_verified: nil)
     }
+    let!(:pub13) { create(:publication,
+                          title: 'pub13',
+                          publication_type: 'Journal Article',
+                          preferred_version: 'acceptedVersion')
+    }
     let!(:activity_insight_oa_file1) { create(:activity_insight_oa_file, publication: pub2) }
     let!(:activity_insight_oa_file2) { create(:activity_insight_oa_file, publication: pub3) }
     let!(:activity_insight_oa_file3) { create(:activity_insight_oa_file, publication: pub4) }
@@ -672,6 +677,22 @@ describe Publication, type: :model do
     let!(:activity_insight_oa_file10) { create(:activity_insight_oa_file, publication: pub11, version: 'publishedVersion') }
     let!(:activity_insight_oa_file11) { create(:activity_insight_oa_file, publication: pub4, version: 'unknown') }
     let!(:activity_insight_oa_file12) { create(:activity_insight_oa_file, publication: pub12, version: 'publishedVersion') }
+    let!(:activity_insight_oa_file13) {
+      create(
+        :activity_insight_oa_file,
+        publication: pub13,
+        version: 'unknown'
+      )
+    }
+    let!(:activity_insight_oa_file13a) {
+      create(
+        :activity_insight_oa_file,
+        publication: pub13,
+        version: 'acceptedVersion',
+        downloaded: true,
+        file_download_location: fixture_file_open('test_file.pdf')
+      )
+    }
 
     let!(:open_access_location) { create(:open_access_location, publication: pub5) }
 
@@ -697,7 +718,8 @@ describe Publication, type: :model do
           pub9j,
           pub10,
           pub11,
-          pub12
+          pub12,
+          pub13
         ]
       end
     end
@@ -722,7 +744,8 @@ describe Publication, type: :model do
           pub9j,
           pub10,
           pub11,
-          pub12
+          pub12,
+          pub13
         ]
       end
     end
@@ -735,7 +758,7 @@ describe Publication, type: :model do
 
     describe '.needs_doi_verification' do
       it 'returns activity_insight_oa_publications whose doi_verified is nil' do
-        expect(described_class.needs_doi_verification).to match_array [pub4, pub11, pub12]
+        expect(described_class.needs_doi_verification).to match_array [pub4, pub11, pub12, pub13]
       end
     end
 
@@ -774,6 +797,13 @@ describe Publication, type: :model do
     describe '.permissions_check_failed' do
       it 'returns activity_insight_oa_publications that have had their permissions checked but are still missing permissions data' do
         expect(described_class.permissions_check_failed).to match_array [pub9a, pub9b, pub9g, pub9h, pub9i, pub9j]
+      end
+    end
+
+    describe '.ready_for_metadata_review' do
+      # TODO: Add more test cases for this query
+      it 'returns activity_insight_oa_publications with a preferred version and a downloaded file that matches the preferred version' do
+        expect(described_class.ready_for_metadata_review).to match_array [pub13]
       end
     end
   end

--- a/spec/factories/activity_insight_oa_file.rb
+++ b/spec/factories/activity_insight_oa_file.rb
@@ -3,6 +3,7 @@
 FactoryBot.define do
   factory :activity_insight_oa_file do
     publication
+    user
     sequence(:location) { |n| "abc123/intellcont/test_file#{n}.pdf" }
     version { nil }
     file_download_location { 'path_to_test_file.pdf' }

--- a/spec/integration/admin/activity_insight_oa_files/show_spec.rb
+++ b/spec/integration/admin/activity_insight_oa_files/show_spec.rb
@@ -29,7 +29,7 @@ describe 'Admin activity insight oa file detail page', type: :feature do
         expect(page).to have_content aif.created_at.strftime('%B %d, %Y')
         expect(page).to have_content aif.updated_at.strftime('%B %d, %Y')
         expect(page).to have_link pub.title
-        expect(page).to have_content 'test_file.pdf'
+        expect(page).to have_link 'test_file.pdf'
         expect(page).to have_content '✓'
       end
     end

--- a/spec/integration/admin/activity_insight_oa_files/show_spec.rb
+++ b/spec/integration/admin/activity_insight_oa_files/show_spec.rb
@@ -8,7 +8,9 @@ describe 'Admin activity insight oa file detail page', type: :feature do
   let!(:aif) do
     create(:activity_insight_oa_file,
            publication: pub,
-           version: 'unknown')
+           version: 'unknown',
+           downloaded: true,
+           file_download_location: fixture_file_open('test_file.pdf'))
   end
 
   context 'when the current user is an admin' do
@@ -24,6 +26,8 @@ describe 'Admin activity insight oa file detail page', type: :feature do
         expect(page).to have_content aif.created_at.strftime('%B %d, %Y')
         expect(page).to have_content aif.updated_at.strftime('%B %d, %Y')
         expect(page).to have_link pub.title
+        expect(page).to have_content 'test_file.pdf'
+        expect(page).to have_content "✓"
       end
     end
   end

--- a/spec/integration/admin/activity_insight_oa_files/show_spec.rb
+++ b/spec/integration/admin/activity_insight_oa_files/show_spec.rb
@@ -27,7 +27,7 @@ describe 'Admin activity insight oa file detail page', type: :feature do
         expect(page).to have_content aif.updated_at.strftime('%B %d, %Y')
         expect(page).to have_link pub.title
         expect(page).to have_content 'test_file.pdf'
-        expect(page).to have_content "✓"
+        expect(page).to have_content '✓'
       end
     end
   end

--- a/spec/integration/admin/activity_insight_oa_files/show_spec.rb
+++ b/spec/integration/admin/activity_insight_oa_files/show_spec.rb
@@ -5,8 +5,10 @@ require 'integration/admin/shared_examples_for_admin_page'
 
 describe 'Admin activity insight oa file detail page', type: :feature do
   let!(:pub) { create(:publication, title: "AIF's Publication's Title") }
+  let!(:u) { create(:user) }
   let!(:aif) do
     create(:activity_insight_oa_file,
+           user: u,
            publication: pub,
            version: 'unknown',
            downloaded: true,
@@ -23,6 +25,7 @@ describe 'Admin activity insight oa file detail page', type: :feature do
         expect(page).to have_content "Details for Activity insight OA file 'ActivityInsightOAFile ##{aif.id}'"
         expect(page).to have_content aif.location
         expect(page).to have_content aif.version
+        expect(page).to have_link 'Test User'
         expect(page).to have_content aif.created_at.strftime('%B %d, %Y')
         expect(page).to have_content aif.updated_at.strftime('%B %d, %Y')
         expect(page).to have_link pub.title

--- a/spec/integration/admin/activity_insight_oa_workflow/dashboard_spec.rb
+++ b/spec/integration/admin/activity_insight_oa_workflow/dashboard_spec.rb
@@ -6,9 +6,19 @@ describe 'Admin Activity Insight OA Workflow dashboard', type: :feature do
   let!(:aif1) { create(:activity_insight_oa_file, publication: pub1) }
   let!(:aif2) { create(:activity_insight_oa_file, publication: pub2, version: 'unknown') }
   let!(:aif3) { create(:activity_insight_oa_file, publication: pub3) }
+  let!(:aif4) {
+    create(
+      :activity_insight_oa_file,
+      publication: pub4,
+      version: 'acceptedVersion',
+      downloaded: true,
+      file_download_location: fixture_file_open('test_file.pdf')
+    )
+  }
   let!(:pub1) { create(:publication, doi_verified: false) }
   let!(:pub2) { create(:publication, preferred_version: 'acceptedVersion') }
   let!(:pub3) { create(:publication, permissions_last_checked_at: Time.now) }
+  let!(:pub4) { create(:publication, preferred_version: 'acceptedVersion') }
 
   context 'when the current user is an admin' do
     before do
@@ -41,6 +51,13 @@ describe 'Admin Activity Insight OA Workflow dashboard', type: :feature do
       it 'redirects to the Permissions Review page' do
         click_on 'Review Permissions'
         expect(page).to have_current_path activity_insight_oa_workflow_permissions_review_path
+      end
+    end
+
+    describe 'clicking the link to the Metadata Review page' do
+      it 'redirects to the Metadata Review page' do
+        click_on 'Review Publication Metadata'
+        expect(page).to have_current_path activity_insight_oa_workflow_metadata_review_path
       end
     end
   end

--- a/spec/integration/admin/activity_insight_oa_workflow/dashboard_spec.rb
+++ b/spec/integration/admin/activity_insight_oa_workflow/dashboard_spec.rb
@@ -18,7 +18,15 @@ describe 'Admin Activity Insight OA Workflow dashboard', type: :feature do
   let!(:pub1) { create(:publication, doi_verified: false) }
   let!(:pub2) { create(:publication, preferred_version: 'acceptedVersion') }
   let!(:pub3) { create(:publication, permissions_last_checked_at: Time.now) }
-  let!(:pub4) { create(:publication, preferred_version: 'acceptedVersion') }
+  let!(:pub4) {
+    create(
+      :publication,
+      preferred_version: 'acceptedVersion',
+      licence: 'license',
+      set_statement: 'statement',
+      embargo_date: Date.current
+    )
+  }
 
   context 'when the current user is an admin' do
     before do

--- a/spec/integration/admin/activity_insight_oa_workflow/metadata_review_spec.rb
+++ b/spec/integration/admin/activity_insight_oa_workflow/metadata_review_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'integration/integration_spec_helper'
+
+describe 'Admin Metadata Review dashboard', type: :feature do
+  let!(:aif1) {
+    create(
+      :activity_insight_oa_file,
+      publication: pub1,
+      version:'publishedVersion',
+      downloaded: true,
+      file_download_location: fixture_file_open('test_file.pdf')
+    )
+  }
+  let!(:aif2) {
+    create(
+      :activity_insight_oa_file,
+      publication: pub2,
+      version: 'acceptedVersion',
+      downloaded: true,
+      file_download_location: fixture_file_open('test_file.pdf')
+    )
+  }
+  let!(:aif3) {
+    create(
+      :activity_insight_oa_file,
+      publication: pub3,
+      version: nil,
+      downloaded: true,
+      file_download_location: fixture_file_open('test_file.pdf')
+    )
+  }
+  let!(:pub1) { create(:publication, title: 'Pub1', preferred_version: 'acceptedVersion' ) }
+  let!(:pub2) { create(:publication, title: 'Pub2', preferred_version: 'acceptedVersion' ) }
+  let!(:pub3) { create(:publication, title: 'Pub3', preferred_version: nil) }
+
+  before do
+    authenticate_admin_user
+    visit activity_insight_oa_workflow_metadata_review_path
+  end
+
+  describe 'listing publications that are ready for final metadata review prior to ScholarSphere deposit' do
+    it 'show a table with header and the proper data for the publications in the table' do
+      expect(page).to have_text('Pub2')
+
+      expect(page).not_to have_text('Pub1')
+      expect(page).not_to have_text('Pub3')
+    end
+  end
+
+  describe 'clicking "<< Back"' do
+    it 'redirects to the OA Workflow Dashboard' do
+      click_link '<< Back'
+      expect(page).to have_current_path activity_insight_oa_workflow_path
+    end
+  end
+
+  describe 'clicking a link to edit a publication' do
+    it "redirects to that publication's edit page" do
+      click_link pub2.title
+      expect(page).to have_current_path rails_admin.edit_path(model_name: :publication, id: pub2.id)
+    end
+  end
+end

--- a/spec/integration/admin/activity_insight_oa_workflow/metadata_review_spec.rb
+++ b/spec/integration/admin/activity_insight_oa_workflow/metadata_review_spec.rb
@@ -31,7 +31,16 @@ describe 'Admin Metadata Review dashboard', type: :feature do
     )
   }
   let!(:pub1) { create(:publication, title: 'Pub1', preferred_version: 'acceptedVersion') }
-  let!(:pub2) { create(:publication, title: 'Pub2', preferred_version: 'acceptedVersion') }
+  let!(:pub2) {
+    create(
+      :publication,
+      title: 'Pub2',
+      preferred_version: 'acceptedVersion',
+      licence: 'license',
+      set_statement: 'statement',
+      embargo_date: Date.current
+    )
+  }
   let!(:pub3) { create(:publication, title: 'Pub3', preferred_version: nil) }
 
   before do

--- a/spec/integration/admin/activity_insight_oa_workflow/metadata_review_spec.rb
+++ b/spec/integration/admin/activity_insight_oa_workflow/metadata_review_spec.rb
@@ -7,7 +7,7 @@ describe 'Admin Metadata Review dashboard', type: :feature do
     create(
       :activity_insight_oa_file,
       publication: pub1,
-      version:'publishedVersion',
+      version: 'publishedVersion',
       downloaded: true,
       file_download_location: fixture_file_open('test_file.pdf')
     )
@@ -30,8 +30,8 @@ describe 'Admin Metadata Review dashboard', type: :feature do
       file_download_location: fixture_file_open('test_file.pdf')
     )
   }
-  let!(:pub1) { create(:publication, title: 'Pub1', preferred_version: 'acceptedVersion' ) }
-  let!(:pub2) { create(:publication, title: 'Pub2', preferred_version: 'acceptedVersion' ) }
+  let!(:pub1) { create(:publication, title: 'Pub1', preferred_version: 'acceptedVersion') }
+  let!(:pub2) { create(:publication, title: 'Pub2', preferred_version: 'acceptedVersion') }
   let!(:pub3) { create(:publication, title: 'Pub3', preferred_version: nil) }
 
   before do

--- a/spec/integration/admin/publications/show_spec.rb
+++ b/spec/integration/admin/publications/show_spec.rb
@@ -88,6 +88,9 @@ describe 'Admin publication detail page', type: :feature do
   let!(:journal) { create(:journal,
                           title: 'Test Journal Record') }
 
+  let!(:ai_file) { create(:activity_insight_oa_file,
+                          publication: pub) }
+
   context 'when the current user is an admin' do
     before { authenticate_admin_user }
 
@@ -130,6 +133,9 @@ describe 'Admin publication detail page', type: :feature do
                                   href: rails_admin.show_path(model_name: :open_access_location, id: oal_ss.id)
         expect(page).to have_link 'https://openaccess.org/publications/oal3',
                                   href: rails_admin.show_path(model_name: :open_access_location, id: oal_oab.id)
+
+        expect(page).to have_link "ActivityInsightOAFile ##{ai_file.id}",
+                                  href: rails_admin.show_path(model_name: :activity_insight_oa_file, id: ai_file.id)
 
         expect(page).to have_link 'Test Journal Record', href: rails_admin.show_path(model_name: :journal, id: journal.id)
 


### PR DESCRIPTION
@ajkiessl

This PR contains the new association between `User` and `ActivityInsightOAFile` records. It also contains the new list of publications that are ready for metadata review prior to deposit. The list functionality isn't complete yet, but I wanted to get this merged in at this point since it's all working and several other things will depend on the user/file association.

There's also a temporary change to the Activity Insight import that will populate the `User` association for existing `ActivityInsightOAFile` records. We don't need to release this to production right away if you don't want, but after it has eventually been released and the updated Activity Insight import has been run, we can undo that change.