### PR TITLE
adds rake tasks for pulling rmd data from s3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ orbs:
   docker: circleci/docker@2.2.0
   ruby: circleci/ruby@1.0
   node: circleci/node@2
-  browser-tools: circleci/browser-tools@1.4.3
+  browser-tools: circleci/browser-tools@1.4.4
 
 jobs:
   release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,8 @@ jobs:
       RAILS_ENV: test
     # A series of steps to run, some are similar to those in "build".
     steps:
-      - browser-tools/install-chrome
+      - browser-tools/install-chrome:
+          chrome-version: '116.0.5845.110'
       - browser-tools/install-chromedriver
       - checkout
       - ruby/install-deps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,8 +89,7 @@ jobs:
       RAILS_ENV: test
     # A series of steps to run, some are similar to those in "build".
     steps:
-      - browser-tools/install-chrome:
-          chrome-version: '116.0.5845.110'
+      - browser-tools/install-chrome
       - browser-tools/install-chromedriver
       - checkout
       - ruby/install-deps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,8 @@ jobs:
       RAILS_ENV: test
     # A series of steps to run, some are similar to those in "build".
     steps:
-      - browser-tools/install-chrome
+      - browser-tools/install-chrome:
+          chrome-version: 116.0.5845.96
       - browser-tools/install-chromedriver
       - checkout
       - ruby/install-deps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,6 +89,7 @@ jobs:
       RAILS_ENV: test
     # A series of steps to run, some are similar to those in "build".
     steps:
+      - run: sudo apt-get update
       - browser-tools/install-chrome:
           chrome-version: 116.0.5845.96
       - browser-tools/install-chromedriver

--- a/Gemfile
+++ b/Gemfile
@@ -78,6 +78,7 @@ group :development do
   gem 'spring'
   gem 'spring-commands-rspec'
   gem 'spring-watcher-listen', '~> 2.0.0'
+  gem 'tty-prompt'
   gem 'web-console', '>= 3.3.0'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -412,6 +412,8 @@ GEM
     parallel (1.22.1)
     parser (3.2.0.0)
       ast (~> 2.4.1)
+    pastel (0.8.0)
+      tty-color (~> 0.5)
     pdf-reader (2.10.0)
       Ascii85 (~> 1.0)
       afm (~> 0.2.1)
@@ -619,6 +621,16 @@ GEM
     tilt (2.0.11)
     timeout (0.3.0)
     ttfunk (1.7.0)
+    tty-color (0.6.0)
+    tty-cursor (0.7.1)
+    tty-prompt (0.23.1)
+      pastel (~> 0.8)
+      tty-reader (~> 0.8)
+    tty-reader (0.9.0)
+      tty-cursor (~> 0.7)
+      tty-screen (~> 0.8)
+      wisper (~> 2.0)
+    tty-screen (0.8.1)
     turbolinks (5.2.1)
       turbolinks-source (~> 5.2)
     turbolinks-source (5.2.0)
@@ -650,6 +662,7 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    wisper (2.0.1)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.6.7)
@@ -731,6 +744,7 @@ DEPENDENCIES
   string-similarity
   strscan (~> 3.0.1)
   terser
+  tty-prompt
   turbolinks (~> 5)
   vcr
   view_component

--- a/lib/tasks/database_data.rake
+++ b/lib/tasks/database_data.rake
@@ -34,7 +34,7 @@ namespace :database_data do
     download_from_s3
   end
 
-  task :load_from_backup, [:dump_file] => :environment do | _t, args|
+  task :load_from_backup, [:dump_file] => :environment do |_t, args|
     desc 'Loads a database backup into the development environment'
     filename = args[:dump_file]
     db_config = Rails.configuration.database_configuration

--- a/lib/tasks/database_data.rake
+++ b/lib/tasks/database_data.rake
@@ -5,11 +5,10 @@ require 'aws-sdk-s3'
 require 'tty-prompt'
 
 namespace :database_data do
-  # These tasks are for getting production data into local, qa, and stage environments
-  # :get_prod_data_file should be run first
-  # Then run :load_to_local, :load_to_qa, or :load_to_stage to load the data into
-  # your local, qa, or stage environments respectively
-  # These tasks should be run from the root directory of the application on your local machine
+  # These tasks are for getting production data into local environments
+  # download_from_s3 expects an AWS environment setup
+  # For PSU aws, the following command should get you there (given you've configured aws sso)
+  # eval "$(aws configure export-credentials --format env)"
 
   def download_from_s3
     bucket = ENV.fetch('AWS_BUCKET', 'edu.psu.libraries.devteam.rmd-backup')
@@ -30,7 +29,7 @@ namespace :database_data do
   end
 
   task download_from_s3: :environment do
-    desc 'Downloads a database dump from s3'
+    desc 'Downloads a database dump from S3'
     download_from_s3
   end
 
@@ -67,140 +66,5 @@ namespace :database_data do
 
     # Catch up on any migrations
     ActiveRecord::Tasks::DatabaseTasks.migrate
-  end
-
-  task get_prod_data_file: :environment do
-    desc 'Pull production data down as a sql.gz file and store it in the tmp directory'
-    datetime = DateTime.now.to_s
-    filename = "psql-rmd-prod-data-#{datetime}.sql"
-    hostname = 'rmdweb1prod'
-
-    Net::SSH.start(hostname, 'deploy', port: 1855) do |ssh|
-      # Pull down db config to be parsed
-      db_config = Rails.configuration.database_configuration
-
-      # Parse values from db config
-      db_password = db_config['production']['password']
-      db_username = db_config['production']['username']
-      db_host = db_config['production']['host']
-      db_name = db_config['production']['database']
-
-      # Dump data into sql file and gzip
-      pg_prog = ProgressBar.create(total: nil, title: 'pg_dump', format: '%t |%B| %a')
-      Thread.new { until pg_prog.finished? do pg_prog.increment; sleep(0.2); end }
-      ssh.exec!("PGPASSWORD=#{db_password} pg_dump --clean \
-                                                             --no-owner \
-                                                             -U #{db_username} \
-                                                             -h #{db_host} \
-                                                             -d #{db_name} > #{filename}")
-      pg_prog.finish
-
-      # Gzip file
-      gz_prog = ProgressBar.create(total: nil, title: 'gzip', format: '%t |%B| %a')
-      Thread.new { until gz_prog.finished? do gz_prog.increment; sleep(0.2); end }
-      ssh.exec!("gzip #{filename}")
-      gz_prog.finish
-
-      # Pull db dump down to local application's tmp directory
-      rsync_prog = ProgressBar.create(total: nil, title: 'rsync', format: '%t |%B| %a')
-      Thread.new { until rsync_prog.finished? do rsync_prog.increment; sleep(0.2); end }
-      `rsync -e 'ssh -p 1855' -P deploy@#{hostname}:~/#{filename}.gz #{Rails.root}/tmp/#{filename}.gz`
-      rsync_prog.finish
-
-      # Delete file on server
-      ssh.exec!("rm #{filename}.gz")
-    end
-  end
-
-  task load_to_local: :environment do
-    desc 'Load the gzipped sql file in the tmp directory into the local postgres db'
-    filename = File.basename(Dir["#{Rails.root}/tmp/psql-rmd-prod-data-*.sql.gz"].first, '.gz')
-
-    # Get local db config
-    db_config = Rails.configuration.database_configuration
-
-    # Unzip production data file
-    `gunzip #{Rails.root}/tmp/#{filename}.gz`
-
-    # Load data into local db
-    psql_prog = ProgressBar.create(total: nil, title: 'psql', format: '%t |%B| %a')
-    Thread.new { until psql_prog.finished? do psql_prog.increment; sleep(0.2); end }
-    `psql #{db_config['development']['database']} < #{Rails.root}/tmp/#{filename}`
-    psql_prog.finish
-
-    # Delete the data file
-    Dir.glob("#{Rails.root}/tmp/psql-rmd-prod-data-*.sql").each { |file| File.delete(file) }
-  end
-
-  task load_to_qa: :environment do
-    desc 'Load the gzipped sql file in the tmp directory into the qa postgres db'
-    filename = File.basename(Dir["#{Rails.root}/tmp/psql-rmd-prod-data-*.sql.gz"].first, '.gz')
-    hostname = 'rmdweb1qa'
-
-    Net::SSH.start(hostname, 'deploy', port: 1855) do |ssh|
-      # Pull down db config to be parsed
-      db_config = Rails.configuration.database_configuration
-
-      # Parse values from db config
-      db_password = db_config['staging']['password']
-      db_username = db_config['staging']['username']
-      db_host = db_config['staging']['host']
-      db_name = db_config['staging']['database']
-
-      # Push file out to qa
-      rsync_prog = ProgressBar.create(total: nil, title: 'rsync', format: '%t |%B| %a')
-      Thread.new { until rsync_prog.finished? do rsync_prog.increment; sleep(0.2); end }
-      `rsync -e 'ssh -p 1855' #{Rails.root}/tmp/#{filename}.gz deploy@#{hostname}:~/#{filename}.gz`
-      rsync_prog.finish
-
-      # Unzip production data file and load it into the qa postgres db
-      psql_prog = ProgressBar.create(total: nil, title: 'psql', format: '%t |%B| %a')
-      Thread.new { until psql_prog.finished? do psql_prog.increment; sleep(0.2); end }
-      ssh.exec!("gunzip #{filename}.gz")
-      ssh.exec!("PGPASSWORD=#{db_password} 'psql  -U #{db_username} \
-                                                            -h #{db_host} \
-                                                            -d #{db_name} < #{filename};
-                                                      rm #{filename}")
-      psql_prog.finish
-    end
-
-    # Delete the data file
-    Dir.glob("#{Rails.root}/tmp/psql-rmd-prod-data-*.sql.gz").each { |file| File.delete(file) }
-  end
-
-  task load_to_stage: :environment do
-    desc 'Load the gzipped sql file in the tmp directory into the stage postgres db'
-    filename = File.basename(Dir["#{Rails.root}/tmp/psql-rmd-prod-data-*.sql.gz"].first, '.gz')
-    hostname = 'rmdweb1stage'
-
-    Net::SSH.start(hostname, 'deploy', port: 1855) do |ssh|
-      # Pull down db config to be parsed
-      db_config = Rails.configuration.database_configuration
-
-      # Parse values from db config
-      db_password = db_config['beta']['password']
-      db_username = db_config['beta']['username']
-      db_host = db_config['beta']['host']
-      db_name = db_config['beta']['database']
-
-      # Push file out to stage
-      rsync_prog = ProgressBar.create(total: nil, title: 'rsync', format: '%t |%B| %a')
-      Thread.new { until rsync_prog.finished? do rsync_prog.increment; sleep(0.2); end }
-      `rsync -e 'ssh -p 1855' #{Rails.root}/tmp/#{filename}.gz deploy@#{hostname}:~/#{filename}.gz`
-      rsync_prog.finish
-
-      # Unzip production data file and load it into the stage postgres db
-      psql_prog = ProgressBar.create(total: nil, title: 'psql', format: '%t |%B| %a')
-      Thread.new { until psql_prog.finished? do psql_prog.increment; sleep(0.2); end }
-      ssh.exec!("gunzip #{filename}.gz")
-      ssh.exec!("PGPASSWORD=#{db_password} psql  -U #{db_username} \
-                                                           -h #{db_host} \
-                                                           -d #{db_name} < #{filename};
-                                                     rm #{filename}")
-      psql_prog.finish
-    end
-
-    # Delete the data file
-    Dir.glob("#{Rails.root}/tmp/psql-rmd-prod-data-*.sql.gz").each { |file| File.delete(file) }
   end
 end


### PR DESCRIPTION
Adds two rake tasks to facilitate getting a database dump into a local environment. These rake tasks assume that your local aws environment is setup. e.g (`eval $(aws configure --profile=default export-credentials --format env)`)

to pull from another bucket, you can set the `AWS_BUCKET` and `AWS_PREFIX` parameters. they are defaulted to the rmd backup bucket.

`database_data:download_from_s3` will look for the files in the bucket prefix, allow a user to select one, and download it to `Rails.root/tmp`

`database_data:load_from_backup` when called without a dump_file parameter will call download_from_s3, and then load that file into the development database. 

`database_data:load_from_backup:[/path/to/dumpfile']` will skip downloading from s3 again, and load in the passed file.
