### PR TITLE
Cleanup secondary titles

### DIFF
--- a/app/services/doi_verification_service.rb
+++ b/app/services/doi_verification_service.rb
@@ -10,7 +10,7 @@ class DOIVerificationService
   end
 
   def verify
-    pub_title = publication.matchable_title + publication.matchable_secondary_title
+    pub_title = publication.matchable_title
     unpaywall_title = UnpaywallClient.query_unpaywall(publication).matchable_title
     publication.doi_verified = compare_title(pub_title, unpaywall_title)
     publication.save!

--- a/app/services/subtitle_cleanup_service.rb
+++ b/app/services/subtitle_cleanup_service.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class SubtitleCleanupService
+  def self.call
+    Publication.find_each do |publication|
+      if publication.secondary_title.present?
+        publication.update(secondary_title: nil) if publication.title.include?(publication.secondary_title)
+      end
+    end
+  end
+end

--- a/lib/tasks/migrate_open_access_urls.rake
+++ b/lib/tasks/migrate_open_access_urls.rake
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-desc 'Migrate open access URLs from old data model to new data model'
-task migrate_open_access_urls: :environment do
-  OpenAccessUrlsMigrationService.call
-end

--- a/lib/tasks/subtitle_cleanup.rake
+++ b/lib/tasks/subtitle_cleanup.rake
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+desc 'Runs SubtitleCleanupService to remove secondary_titles
+      if they are included in the title'
+task subtitle_cleanup: :environment do
+  SubtitleCleanupService.call
+end

--- a/spec/component/services/doi_verification_service_spec.rb
+++ b/spec/component/services/doi_verification_service_spec.rb
@@ -9,7 +9,7 @@ describe DOIVerificationService do
                              secondary_title: secondary_title,
                              doi_verified: nil)}
   let(:title) { 'Psychotherapy integration and the need for better theories of change: A rejoinder to Alford' }
-  let(:secondary_title) { nil }
+  let(:secondary_title) { 'Theories of change for psychotherapy integration' }
   let(:service) { described_class.new(publication) }
   let(:json) { Rails.root.join('spec', 'fixtures', 'unpaywall2.json').read }
 
@@ -49,16 +49,6 @@ describe DOIVerificationService do
       it 'updates the doi verified status in publication record' do
         service.verify
         expect(publication.reload.doi_verified).to be false
-      end
-    end
-
-    context 'when the publication has a secondary title' do
-      let(:title) { 'Psychotherapy integration and the need for better theories of change' }
-      let(:secondary_title) { 'A rejoinder to Alford' }
-
-      it 'updates the doi verified status in publication record' do
-        service.verify
-        expect(publication.reload.doi_verified).to be true
       end
     end
   end

--- a/spec/component/services/subtitle_cleanup_service_spec.rb
+++ b/spec/component/services/subtitle_cleanup_service_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'component/component_spec_helper'
+
+describe SubtitleCleanupService do
+  let!(:publication1) { create :sample_publication }
+  let!(:publication2) { create :sample_publication }
+  let!(:publication3) { create :sample_publication }
+  let!(:publication4) { create :sample_publication, secondary_title: nil }
+  let!(:publication5) { create :sample_publication, secondary_title: '' }
+  let!(:publication6) { create :sample_publication }
+  let!(:publication7) { create :sample_publication }
+
+  before do
+    publication1.update title: publication1.title + ': ' + publication1.secondary_title
+    publication2.update title: publication2.title + ': ' + publication2.secondary_title
+    publication3.update title: publication3.secondary_title
+  end
+
+  describe '.call' do
+    subject(:call) { described_class.call }
+
+    it 'updates secondary_title to nil if secondary_title is included in the title' do
+      call
+      expect(publication1.reload.secondary_title).to eq nil
+      expect(publication2.reload.secondary_title).to eq nil
+      expect(publication3.reload.secondary_title).to eq nil
+      expect(publication4.reload).to eq publication4
+      expect(publication5.reload).to eq publication5
+      expect(publication6.reload).to eq publication6
+      expect(publication7.reload).to eq publication7
+    end
+  end
+end


### PR DESCRIPTION
Removes rake task that no longer works.  Adds SubtitleCleanupService to remove secondary titles from pubs if it is contained in the title.  Rake task and test for this.  Removes secondary title check in DoiVerificationService