### PR TITLE
File open and edit bug fix

### DIFF
--- a/app/views/activity_insight_oa_workflow/doi_verification/index.html.erb
+++ b/app/views/activity_insight_oa_workflow/doi_verification/index.html.erb
@@ -20,7 +20,9 @@
           <td>Failed Verification</td>
           <td class="file-name"><% p.activity_insight_oa_files.each do |f| %>
                 <% if f.stored_file_path.present? %>
-                  <%= link_to "#{f.download_filename}", activity_insight_oa_workflow_file_download_path(f.id) %>
+                  <%= link_to "#{f.download_filename}",
+                              activity_insight_oa_workflow_file_download_path(f.id),
+                              target: '_blank' %>
                 <% else %>
                   Not Found
                 <% end %>

--- a/app/views/activity_insight_oa_workflow/file_version_curation/index.html.erb
+++ b/app/views/activity_insight_oa_workflow/file_version_curation/index.html.erb
@@ -25,7 +25,9 @@
                 </td>
                 <td class="file-name"><% p.activity_insight_oa_files.each do |f| %>
                 <% if f.stored_file_path.present? %>
-                  <%= link_to "#{f.download_filename}", activity_insight_oa_workflow_file_download_path(f.id) %>
+                  <%= link_to "#{f.download_filename}", 
+                              activity_insight_oa_workflow_file_download_path(f.id),
+                              target: '_blank' %>
                 <% else %>
                   Not Found
                 <% end %>

--- a/app/views/activity_insight_oa_workflow/file_version_curation/index.html.erb
+++ b/app/views/activity_insight_oa_workflow/file_version_curation/index.html.erb
@@ -25,7 +25,7 @@
                 </td>
                 <td class="file-name"><% p.activity_insight_oa_files.each do |f| %>
                 <% if f.stored_file_path.present? %>
-                  <%= link_to "#{f.download_filename}", 
+                  <%= link_to "#{f.download_filename}",
                               activity_insight_oa_workflow_file_download_path(f.id),
                               target: '_blank' %>
                 <% else %>

--- a/app/views/activity_insight_oa_workflow/permissions_curation/index.html.erb
+++ b/app/views/activity_insight_oa_workflow/permissions_curation/index.html.erb
@@ -24,7 +24,9 @@
           <td id="preferred-version"><%= p.preferred_version.present? ? p.preferred_version_display : 'Not Found' %></td>
           <td class="file-name"><% p.activity_insight_oa_files.each do |f| %>
             <% if f.stored_file_path.present? %>
-              <%= link_to "#{f.download_filename}", activity_insight_oa_workflow_file_download_path(f.id) %>
+              <%= link_to "#{f.download_filename}",
+                          activity_insight_oa_workflow_file_download_path(f.id),
+                          target: '_blank' %>
             <% else %>
               Not Found
             <% end %>

--- a/app/views/activity_insight_oa_workflow/wrong_file_version_curation/index.html.erb
+++ b/app/views/activity_insight_oa_workflow/wrong_file_version_curation/index.html.erb
@@ -47,7 +47,9 @@
             </td>
             <td class="file-name">
                 <% if file.stored_file_path.present? %>
-                  <%= link_to "#{file.download_filename}", activity_insight_oa_workflow_file_download_path(file.id) %>
+                  <%= link_to "#{file.download_filename}",
+                              activity_insight_oa_workflow_file_download_path(file.id),
+                              target: '_blank' %>
                 <% else %>
                   Not Found
                 <% end %>


### PR DESCRIPTION
Adds `target: _blank` to links to pdf downloads.  Not too sure why, but this fixes the issue.

closes #823 