### PR TITLE
Give APITokens access to descendant organizations

### DIFF
--- a/app/controllers/api/v1/organizations_controller.rb
+++ b/app/controllers/api/v1/organizations_controller.rb
@@ -3,11 +3,11 @@
 module API::V1
   class OrganizationsController < APIController
     def index
-      render json: API::V1::OrganizationSerializer.new(api_token.organizations.visible)
+      render json: API::V1::OrganizationSerializer.new(api_token.all_organizations.visible)
     end
 
     def publications
-      org = api_token.organizations.visible.find(params[:id])
+      org = api_token.all_organizations.visible.find(params[:id])
       render json: API::V1::PublicationSerializer.new(org.all_publications)
     end
   end

--- a/app/controllers/api/v1/publications_controller.rb
+++ b/app/controllers/api/v1/publications_controller.rb
@@ -5,7 +5,7 @@ module API::V1
     def index
       limit = params[:limit].presence || 100
 
-      query = api_token.publications.visible.limit(limit)
+      query = api_token.all_current_publications.visible.limit(limit)
 
       if params[:activity_insight_id].present?
         query = Publication.filter_by_activity_insight_id(query, params[:activity_insight_id])
@@ -19,12 +19,12 @@ module API::V1
     end
 
     def show
-      @publication = api_token.publications.visible.find(params[:id])
+      @publication = api_token.all_current_publications.visible.find(params[:id])
       render json: API::V1::PublicationSerializer.new(@publication).serializable_hash
     end
 
     def grants
-      publication = api_token.publications.visible.find(params[:id])
+      publication = api_token.all_current_publications.visible.find(params[:id])
       render json: API::V1::GrantSerializer.new(publication.grants)
     end
 

--- a/app/controllers/api/v1/publications_controller.rb
+++ b/app/controllers/api/v1/publications_controller.rb
@@ -5,7 +5,7 @@ module API::V1
     def index
       limit = params[:limit].presence || 100
 
-      query = api_token.all_current_publications.visible.limit(limit)
+      query = api_token.all_publications.visible.limit(limit)
 
       if params[:activity_insight_id].present?
         query = Publication.filter_by_activity_insight_id(query, params[:activity_insight_id])
@@ -19,12 +19,12 @@ module API::V1
     end
 
     def show
-      @publication = api_token.all_current_publications.visible.find(params[:id])
+      @publication = api_token.all_publications.visible.find(params[:id])
       render json: API::V1::PublicationSerializer.new(@publication).serializable_hash
     end
 
     def grants
-      publication = api_token.all_current_publications.visible.find(params[:id])
+      publication = api_token.all_publications.visible.find(params[:id])
       render json: API::V1::GrantSerializer.new(publication.grants)
     end
 

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -5,7 +5,7 @@ module API::V1
     include ActionController::MimeResponds
 
     def presentations
-      user = api_token.users.find_by(webaccess_id: params[:webaccess_id])
+      user = api_token.all_current_users.find_by(webaccess_id: params[:webaccess_id])
       if user
         @presentations = API::V1::UserQuery.new(user).presentations(params)
         respond_to do |format|
@@ -18,7 +18,7 @@ module API::V1
     end
 
     def grants
-      user = api_token.users.find_by(webaccess_id: params[:webaccess_id])
+      user = api_token.all_current_users.find_by(webaccess_id: params[:webaccess_id])
       if user
         @grants = API::V1::UserQuery.new(user).grants
         respond_to do |format|
@@ -31,7 +31,7 @@ module API::V1
     end
 
     def news_feed_items
-      user = api_token.users.find_by(webaccess_id: params[:webaccess_id])
+      user = api_token.all_current_users.find_by(webaccess_id: params[:webaccess_id])
       if user
         @news_feed_items = API::V1::UserQuery.new(user).news_feed_items(params)
         respond_to do |format|
@@ -44,7 +44,7 @@ module API::V1
     end
 
     def performances
-      user = api_token.users.find_by(webaccess_id: params[:webaccess_id])
+      user = api_token.all_current_users.find_by(webaccess_id: params[:webaccess_id])
       if user
         @performances = API::V1::UserQuery.new(user).performances(params)
         respond_to do |format|
@@ -57,7 +57,7 @@ module API::V1
     end
 
     def etds
-      @user = api_token.users.find_by(webaccess_id: params[:webaccess_id])
+      @user = api_token.all_current_users.find_by(webaccess_id: params[:webaccess_id])
       if @user
         @etds = API::V1::UserQuery.new(@user).etds(params)
         respond_to do |format|
@@ -70,7 +70,7 @@ module API::V1
     end
 
     def publications
-      user = api_token.users.find_by(webaccess_id: params[:webaccess_id])
+      user = api_token.all_current_users.find_by(webaccess_id: params[:webaccess_id])
       if user
         @pubs = API::V1::UserQuery.new(user).publications(params)
         respond_to do |format|
@@ -83,7 +83,7 @@ module API::V1
     end
 
     def organization_memberships
-      user = api_token.users.find_by(webaccess_id: params[:webaccess_id])
+      user = api_token.all_current_users.find_by(webaccess_id: params[:webaccess_id])
       if user
         @memberships = user.user_organization_memberships
         respond_to do |format|
@@ -112,7 +112,7 @@ module API::V1
 
     def users_publications
       data = {}
-      api_token.users.includes(:publications).where(webaccess_id: params[:_json]).each do |user|
+      api_token.all_current_users.includes(:publications).where(webaccess_id: params[:_json]).each do |user|
         pubs = API::V1::UserQuery.new(user).publications(params)
         data[user.webaccess_id] = API::V1::PublicationSerializer.new(pubs).serializable_hash
       end

--- a/app/models/api_token.rb
+++ b/app/models/api_token.rb
@@ -5,8 +5,6 @@ class APIToken < ApplicationRecord
 
   has_many :organization_api_permissions, inverse_of: :api_token
   has_many :organizations, through: :organization_api_permissions
-  has_many :users, through: :organizations
-  has_many :publications, through: :users
 
   def all_publications
     Publication.joins(users: :organizations)

--- a/app/models/api_token.rb
+++ b/app/models/api_token.rb
@@ -19,6 +19,10 @@ class APIToken < ApplicationRecord
         .distinct(:id)
   end
 
+  def all_organizations
+    Organization.where(organization_id: descendant_org_ids)
+  end
+
   def increment_request_count
     update_column(:total_requests, total_requests + 1)
     update_column(:last_used_at, Time.current)

--- a/app/models/api_token.rb
+++ b/app/models/api_token.rb
@@ -8,6 +8,17 @@ class APIToken < ApplicationRecord
   has_many :users, through: :organizations
   has_many :publications, through: :users
 
+  def all_current_publications
+    Publication.joins(users: :organizations).where(organizations: { id: descendant_org_ids }).published_during_membership.distinct(:id)
+  end
+
+  def all_current_users
+    User.joins(:user_organization_memberships)
+        .where(user_organization_memberships: { organization_id: descendant_org_ids })
+        .where('user_organization_memberships.ended_on IS NULL OR user_organization_memberships.ended_on > ?', DateTime.now)
+        .distinct(:id)
+  end
+
   def increment_request_count
     update_column(:total_requests, total_requests + 1)
     update_column(:last_used_at, Time.current)
@@ -57,6 +68,10 @@ class APIToken < ApplicationRecord
   end
 
   private
+
+    def descendant_org_ids
+      organizations.collect(&:descendant_ids).flatten
+    end
 
     def set_token
       self.token ||= SecureRandom.hex(48)

--- a/app/models/api_token.rb
+++ b/app/models/api_token.rb
@@ -8,19 +8,22 @@ class APIToken < ApplicationRecord
   has_many :users, through: :organizations
   has_many :publications, through: :users
 
-  def all_current_publications
-    Publication.joins(users: :organizations).where(organizations: { id: descendant_org_ids }).published_during_membership.distinct(:id)
+  def all_publications
+    Publication.joins(users: :organizations)
+      .where(organizations: { id: descendant_org_ids })
+      .published_during_membership
+      .distinct(:id)
   end
 
   def all_current_users
     User.joins(:user_organization_memberships)
-        .where(user_organization_memberships: { organization_id: descendant_org_ids })
-        .where('user_organization_memberships.ended_on IS NULL OR user_organization_memberships.ended_on > ?', DateTime.now)
-        .distinct(:id)
+      .where(user_organization_memberships: { organization_id: descendant_org_ids })
+      .where('user_organization_memberships.ended_on IS NULL OR user_organization_memberships.ended_on > ?', DateTime.now)
+      .distinct(:id)
   end
 
   def all_organizations
-    Organization.where(organization_id: descendant_org_ids)
+    Organization.where(id: descendant_org_ids).distinct(:id)
   end
 
   def increment_request_count
@@ -74,7 +77,7 @@ class APIToken < ApplicationRecord
   private
 
     def descendant_org_ids
-      organizations.collect(&:descendant_ids).flatten
+      organizations.map(&:descendant_ids).flatten
     end
 
     def set_token

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -21,9 +21,9 @@ class Organization < ApplicationRecord
 
   def all_current_users
     User.joins(:user_organization_memberships)
-        .where(user_organization_memberships: { organization_id: descendant_ids })
-        .where('user_organization_memberships.ended_on IS NULL OR user_organization_memberships.ended_on > ?', DateTime.now)
-        .distinct(:id)
+      .where(user_organization_memberships: { organization_id: descendant_ids })
+      .where('user_organization_memberships.ended_on IS NULL OR user_organization_memberships.ended_on > ?', DateTime.now)
+      .distinct(:id)
   end
 
   def descendant_ids

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -19,6 +19,19 @@ class Organization < ApplicationRecord
     User.joins(:user_organization_memberships).where(user_organization_memberships: { organization_id: descendant_ids }).distinct(:id)
   end
 
+  def all_current_users
+    User.joins(:user_organization_memberships)
+        .where(user_organization_memberships: { organization_id: descendant_ids })
+        .where('user_organization_memberships.ended_on IS NULL OR user_organization_memberships.ended_on > ?', DateTime.now)
+        .distinct(:id)
+  end
+
+  def descendant_ids
+    ActiveRecord::Base.connection.execute(
+      %{WITH RECURSIVE org_tree AS (SELECT id, name, parent_id FROM organizations WHERE id = #{id} UNION SELECT child.id, child.name, child.parent_id FROM organizations AS child JOIN org_tree AS parent ON parent.id = child.parent_id) SELECT * FROM org_tree;}
+    ).to_a.pluck('id')
+  end
+
   def user_count
     all_users.count
   end
@@ -76,12 +89,6 @@ class Organization < ApplicationRecord
   end
 
   private
-
-    def descendant_ids
-      ActiveRecord::Base.connection.execute(
-        %{WITH RECURSIVE org_tree AS (SELECT id, name, parent_id FROM organizations WHERE id = #{id} UNION SELECT child.id, child.name, child.parent_id FROM organizations AS child JOIN org_tree AS parent ON parent.id = child.parent_id) SELECT * FROM org_tree;}
-      ).to_a.pluck('id')
-    end
 
     def all_user_ids
       all_users.pluck(:id)

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -19,13 +19,6 @@ class Organization < ApplicationRecord
     User.joins(:user_organization_memberships).where(user_organization_memberships: { organization_id: descendant_ids }).distinct(:id)
   end
 
-  def all_current_users
-    User.joins(:user_organization_memberships)
-      .where(user_organization_memberships: { organization_id: descendant_ids })
-      .where('user_organization_memberships.ended_on IS NULL OR user_organization_memberships.ended_on > ?', DateTime.now)
-      .distinct(:id)
-  end
-
   def descendant_ids
     ActiveRecord::Base.connection.execute(
       %{WITH RECURSIVE org_tree AS (SELECT id, name, parent_id FROM organizations WHERE id = #{id} UNION SELECT child.id, child.name, child.parent_id FROM organizations AS child JOIN org_tree AS parent ON parent.id = child.parent_id) SELECT * FROM org_tree;}

--- a/spec/component/models/api_token_spec.rb
+++ b/spec/component/models/api_token_spec.rb
@@ -24,8 +24,6 @@ describe APIToken, type: :model do
 
   it { is_expected.to have_many(:organization_api_permissions).inverse_of(:api_token) }
   it { is_expected.to have_many(:organizations).through(:organization_api_permissions) }
-  it { is_expected.to have_many(:users).through(:organizations) }
-  it { is_expected.to have_many(:publications).through(:users) }
 
   describe 'creating a new token' do
     let(:new_token) { described_class.new }

--- a/spec/component/models/organization_spec.rb
+++ b/spec/component/models/organization_spec.rb
@@ -219,6 +219,17 @@ describe Organization, type: :model do
     end
   end
 
+  describe '#descendant_ids' do
+    let!(:org) { create(:organization) }
+    let!(:other_org) { create(:organization) }
+    let!(:child_org) { create(:organization, parent: org) }
+    let!(:child_org_child) { create(:organization, parent: child_org) }
+
+    it 'returns the id of the parent organization and all its descendant organization ids' do
+      expect(org.descendant_ids).to match_array([org.id, child_org.id, child_org_child.id])
+    end
+  end
+
   describe '#oa_email_user_count' do
     xit 'returns the number of users who are members of either the organization itself or one of its descendants and who need an open access reminder email' do
     end

--- a/spec/requests/api/v1/api_docs/publications_spec.rb
+++ b/spec/requests/api/v1/api_docs/publications_spec.rb
@@ -5,13 +5,19 @@ require 'requests/requests_spec_helper'
 RSpec.describe 'api/v1/publications' do
   let!(:user) { create(:user_with_authorships, webaccess_id: 'xyz321') }
   let!(:authorship) { create(:authorship, user: user, publication: publication) }
-  let!(:publication) { create(:publication, visible: true, doi: 'https://doi.org/10.1000/182') }
+  let!(:publication) { create(:publication,
+                              visible: true,
+                              doi: 'https://doi.org/10.1000/182',
+                              published_on: 6.months.ago) }
   let!(:api_token) { create(:api_token, token: 'token123', write_access: true) }
   let!(:grant) { create(:grant) }
   let!(:research_fund) { create(:research_fund, grant: grant, publication: publication) }
   let!(:org) { create(:organization) }
   let!(:oap) { create(:organization_api_permission, api_token: api_token, organization: org) }
-  let!(:uom) { create(:user_organization_membership, organization: org, user: user) }
+  let!(:uom) { create(:user_organization_membership,
+                      organization: org,
+                      user: user,
+                      started_on: 1.year.ago) }
 
   path '/v1/publications' do
     path '/v1/publications/{id}/grants' do

--- a/spec/requests/api/v1/publications_spec.rb
+++ b/spec/requests/api/v1/publications_spec.rb
@@ -23,7 +23,7 @@ describe API::V1::PublicationsController do
     end
 
     context 'when a valid authorization header value is included in the request' do
-      let!(:publications) { create_list(:publication, 10, visible: true) }
+      let!(:publications) { create_list(:publication, 10, visible: true, published_on: 6.months.ago) }
       let!(:invisible_pub) { create(:publication, visible: false) }
       let!(:inaccessible_pub) { create(:publication, visible: true) }
       let(:params) { '' }
@@ -33,7 +33,7 @@ describe API::V1::PublicationsController do
 
       before do
         publications.each { |p| create(:authorship, publication: p, user: user) }
-        create(:user_organization_membership, user: user, organization: org)
+        create(:user_organization_membership, user: user, organization: org, started_on: 1.year.ago)
         create(:organization_api_permission, organization: org, api_token: token)
       end
 
@@ -59,7 +59,7 @@ describe API::V1::PublicationsController do
 
       describe 'params:' do
         describe 'activity_insight_id' do
-          let!(:ai_pub) { create(:publication, visible: true, imports: [pub_import]) }
+          let!(:ai_pub) { create(:publication, visible: true, imports: [pub_import], published_on: 6.months.ago) }
           let!(:pub_import) { create(:publication_import, source: 'Activity Insight', source_identifier: '123') }
 
           before do
@@ -108,7 +108,10 @@ describe API::V1::PublicationsController do
         end
 
         describe 'doi' do
-          let(:doi_pub) { create(:publication, visible: true, doi: 'https://doi.org/10.26207/46a7-9981') }
+          let(:doi_pub) { create(:publication,
+                                 visible: true,
+                                 doi: 'https://doi.org/10.26207/46a7-9981',
+                                 published_on: 6.months.ago) }
 
           before do
             create(:authorship, user: user, publication: doi_pub)
@@ -274,7 +277,9 @@ describe API::V1::PublicationsController do
 
       context 'when valid request params: an activity insight id and a url' do
         let(:activity_insight_id) { '123' }
-        let(:publication) { create(:publication, open_access_locations: open_access_locations) }
+        let(:publication) { create(:publication,
+                                   open_access_locations: open_access_locations,
+                                   published_on: 6.months.ago) }
 
         before do
           create(:api_token, token: 'token123', write_access: true)
@@ -404,8 +409,11 @@ describe API::V1::PublicationsController do
   describe 'GET /v1/publications/:id' do
     let!(:pub) { create(:publication,
                         title: 'requested publication',
-                        visible: visible) }
-    let!(:inaccessible_pub) { create(:publication, visible: true) }
+                        visible: visible,
+                        published_on: 6.months.ago) }
+    let!(:inaccessible_pub) { create(:publication,
+                                     visible: true,
+                                     published_on: 6.months.ago) }
     let!(:token) { create(:api_token,
                           token: 'token123',
                           total_requests: 0,
@@ -416,7 +424,10 @@ describe API::V1::PublicationsController do
 
     before do
       create(:organization_api_permission, organization: org, api_token: token)
-      create(:user_organization_membership, organization: org, user: user)
+      create(:user_organization_membership,
+             organization: org,
+             user: user,
+             started_on: 1.year.ago)
       create(:authorship, user: user, publication: pub)
     end
 
@@ -482,8 +493,12 @@ describe API::V1::PublicationsController do
   end
 
   describe 'GET /v1/publications/:id/grants' do
-    let!(:pub) { create(:publication, visible: visible) }
-    let!(:inaccessible_pub) { create(:publication, visible: true) }
+    let!(:pub) { create(:publication,
+                        visible: visible,
+                        published_on: 6.months.ago) }
+    let!(:inaccessible_pub) { create(:publication,
+                                     visible: true,
+                                     published_on: 6.months.ago) }
     let!(:token) { create(:api_token,
                           token: 'token123',
                           total_requests: 0,
@@ -496,7 +511,10 @@ describe API::V1::PublicationsController do
 
     before do
       create(:organization_api_permission, organization: org, api_token: token)
-      create(:user_organization_membership, organization: org, user: user)
+      create(:user_organization_membership,
+             organization: org,
+             user: user,
+             started_on: 1.year.ago)
       create(:authorship, user: user, publication: pub)
       create(:research_fund, publication: pub, grant: g1)
       create(:research_fund, publication: pub, grant: g2)


### PR DESCRIPTION
Gives APITokens permission to access publications and users from the descendants of its associated organizations via the API.  The publications are filtered down to only include those that were published during the time the associated user was a part of that organization.  The users are filtered down to only include those that are _currently_ members of the organization.  Also, this gives the APIToken access to all descendant organizations from the organization API endpoint.

closes #775 