### PR TITLE
Fixes bug when sending single email from the wrong version list

### DIFF
--- a/app/controllers/activity_insight_oa_workflow/wrong_file_version_curation_controller.rb
+++ b/app/controllers/activity_insight_oa_workflow/wrong_file_version_curation_controller.rb
@@ -6,7 +6,7 @@ class ActivityInsightOAWorkflow::WrongFileVersionCurationController < ActivityIn
   end
 
   def email_author
-    publications = Publication.wrong_file_version.find(params[:publications])
+    publications = Publication.wrong_file_version.where(id: params[:publications])
 
     FacultyNotificationsMailer.wrong_file_version(publications).deliver_now
     ActiveRecord::Base.transaction do
@@ -14,7 +14,7 @@ class ActivityInsightOAWorkflow::WrongFileVersionCurationController < ActivityIn
         pub.update_column(:wrong_oa_version_notification_sent_at, Time.current)
       end
     end
-    flash[:notice] = "Email sent to #{publications.first.activity_insight_upload_user.webaccess_id}}"
+    flash[:notice] = "Email sent to #{publications.first.activity_insight_upload_user.webaccess_id}"
     redirect_to activity_insight_oa_workflow_wrong_file_version_review_path
   end
 end

--- a/spec/integration/admin/activity_insight_oa_workflow/wrong_file_version_review_spec.rb
+++ b/spec/integration/admin/activity_insight_oa_workflow/wrong_file_version_review_spec.rb
@@ -51,7 +51,7 @@ describe 'Admin File Version Review dashboard', type: :feature do
     end
   end
 
-  describe 'clicking the button to send an email notification' do
+  describe 'clicking the button to send a batch email notification' do
     it 'sends an email and displays a confirmation message' do
       click_button('Send Batch Email', match: :first)
       expect(page).to have_current_path activity_insight_oa_workflow_wrong_file_version_review_path
@@ -64,6 +64,22 @@ describe 'Admin File Version Review dashboard', type: :feature do
       expect(current_email.body).to match(/Title 2/)
       expect(pub1.reload.wrong_oa_version_notification_sent_at).not_to be_nil
       expect(pub2.reload.wrong_oa_version_notification_sent_at).not_to be_nil
+    end
+  end
+
+  describe 'clicking the button to send a single email notification' do
+    it 'sends an email and displays a confirmation message' do
+      click_button('Send Email', match: :first)
+      expect(page).to have_current_path activity_insight_oa_workflow_wrong_file_version_review_path
+      expect(page).to have_content('Email sent to abc123')
+      open_email('abc123@psu.edu')
+      expect(current_email).not_to be_nil
+      expect(current_email.body).to match(/Version we have/)
+      expect(current_email.body).to match(/Version that can be deposited/)
+      expect(current_email.body).to match(/Title 1/)
+      expect(current_email.body).not_to match(/Title 2/)
+      expect(pub1.reload.wrong_oa_version_notification_sent_at).not_to be_nil
+      expect(pub2.reload.wrong_oa_version_notification_sent_at).to be_nil
     end
   end
 end

--- a/spec/integration/admin/activity_insight_oa_workflow/wrong_file_version_review_spec.rb
+++ b/spec/integration/admin/activity_insight_oa_workflow/wrong_file_version_review_spec.rb
@@ -69,7 +69,7 @@ describe 'Admin File Version Review dashboard', type: :feature do
 
   describe 'clicking the button to send a single email notification' do
     it 'sends an email and displays a confirmation message' do
-      click_button('Send Email', match: :first)
+      find_all("input[value='Send Email']").first.click
       expect(page).to have_current_path activity_insight_oa_workflow_wrong_file_version_review_path
       expect(page).to have_content('Email sent to abc123')
       open_email('abc123@psu.edu')

--- a/spec/integration/user_profile_spec.rb
+++ b/spec/integration/user_profile_spec.rb
@@ -41,7 +41,7 @@ describe UserProfile do
       it 'updates their identity' do
         described_class.new(user)
         u = user.reload
-        expect(u.first_name).to eq 'Daniel'
+        expect(u.first_name).to eq 'Dan'
         expect(u.middle_name).to eq 'M'
         expect(u.last_name).to eq 'Coughlin'
         expect(u.psu_identity.data['givenName']).to eq 'Daniel'


### PR DESCRIPTION
Adds a test for this too.  The issue was with the `find` to get the publications for the email.  It returns a single record for the single email and an array for the batch email.  In the mailer, the code tries to iterate through the "publications" like an array but encounters an error when trying to iterate through the single record.  I fixed this by making the lookup for the publications a sql query that always returns an array-like object.

fixes https://github.com/psu-libraries/researcher-metadata/issues/719#issuecomment-1743690696