### PR TITLE
Hotfix:  `distinct` AI File scopes

### DIFF
--- a/app/models/activity_insight_oa_file.rb
+++ b/app/models/activity_insight_oa_file.rb
@@ -31,6 +31,7 @@ class ActivityInsightOAFile < ApplicationRecord
       .where(%{NOT EXISTS (SELECT * FROM open_access_locations WHERE open_access_locations.publication_id = publication.id AND open_access_locations.source = '#{Source::SCHOLARSPHERE}')})
       .where.not(location: nil)
       .where(%{(publication.open_access_status != 'gold' AND publication.open_access_status != 'hybrid') OR publication.open_access_status IS NULL})
+      .distinct
   }
 
   scope :ready_for_download, -> {
@@ -55,6 +56,7 @@ class ActivityInsightOAFile < ApplicationRecord
         OR EXISTS (SELECT * FROM open_access_locations WHERE open_access_locations.publication_id = publication.id
         AND open_access_locations.source = '#{Source::SCHOLARSPHERE}')})
       .where(exported_oa_status_to_activity_insight: nil)
+      .distinct
   }
 
   scope :needs_permissions_check, -> {

--- a/spec/component/models/activity_insight_oa_file_spec.rb
+++ b/spec/component/models/activity_insight_oa_file_spec.rb
@@ -132,7 +132,8 @@ RSpec.describe ActivityInsightOAFile, type: :model do
     let!(:pub3) { create(:publication,
                          title: 'pub3',
                          open_access_locations: [
-                           build(:open_access_location, source: Source::OPEN_ACCESS_BUTTON, url: 'url', publication: nil)
+                           build(:open_access_location, source: Source::OPEN_ACCESS_BUTTON, url: 'url1', publication: nil),
+                           build(:open_access_location, source: Source::OPEN_ACCESS_BUTTON, url: 'url2', publication: nil)
                          ],
                          open_access_status: 'green')
     }
@@ -144,6 +145,7 @@ RSpec.describe ActivityInsightOAFile, type: :model do
                          title: 'pub5',
                          open_access_status: 'hybrid',
                          open_access_locations: [
+                           build(:open_access_location, source: Source::UNPAYWALL, url: 'url', publication: nil),
                            build(:open_access_location, source: Source::UNPAYWALL, url: 'url', publication: nil)
                          ])
     }

--- a/spec/component/models/activity_insight_oa_file_spec.rb
+++ b/spec/component/models/activity_insight_oa_file_spec.rb
@@ -145,8 +145,8 @@ RSpec.describe ActivityInsightOAFile, type: :model do
                          title: 'pub5',
                          open_access_status: 'hybrid',
                          open_access_locations: [
-                           build(:open_access_location, source: Source::UNPAYWALL, url: 'url', publication: nil),
-                           build(:open_access_location, source: Source::UNPAYWALL, url: 'url', publication: nil)
+                           build(:open_access_location, source: Source::UNPAYWALL, url: 'url1', publication: nil),
+                           build(:open_access_location, source: Source::UNPAYWALL, url: 'url2', publication: nil)
                          ])
     }
     let!(:pub6) { create(:publication,


### PR DESCRIPTION
It appears the double `left_outer_joins` cause duplicates in the `ActivityInsightOAFile` scopes.  I added `distinct`s to the end of the scopes to get rid of the duplicates.  I also added some oa locations to some of the test fixtures to test that the duplicates are removed by the `distinct`.

I'm not sure if there's another way to fix this.  Changing one, or both, of the outer joins to regular joins doesn't fix it.