### PR TITLE
AI OA Workflow ScholarSphere deposit

### DIFF
--- a/app/controllers/activity_insight_oa_workflow/metadata_curation_controller.rb
+++ b/app/controllers/activity_insight_oa_workflow/metadata_curation_controller.rb
@@ -7,5 +7,36 @@ class ActivityInsightOAWorkflow::MetadataCurationController < ActivityInsightOAW
 
   def show
     @publication = Publication.ready_for_metadata_review.find(params[:publication_id])
+  rescue ActiveRecord::RecordNotFound
+    flash[:notice] = 'This publication is not ready for metadata review.'
+    redirect_to activity_insight_oa_workflow_metadata_review_path
+  end
+
+  def create_scholarsphere_deposit
+    publication = Publication.find(params[:publication_id])
+    activity_insight_oa_file = publication.ai_file_for_deposit
+    authorship = Authorship.find_by(user: activity_insight_oa_file.user, 
+                                    publication: publication)
+    @deposit = ScholarsphereWorkDeposit.new_from_authorship(authorship, 
+                                                            rights: activity_insight_oa_file.license, 
+                                                            publisher_statement: activity_insight_oa_file.set_statement, 
+                                                            embargoed_until: activity_insight_oa_file.embargo_date,
+                                                            deposit_agreement: true,
+                                                            deposited_at: Time.now,
+                                                            deposit_workflow: 'Activity Insight OA Workflow')
+    @deposit.file_uploads = []
+    ss_file_upload = ScholarsphereFileUpload.new
+    ss_file_upload.file = activity_insight_oa_file.file_download_location.file
+    ss_file_upload.save!
+    @deposit.file_uploads << ss_file_upload
+    @deposit.save!
+
+    ScholarsphereUploadJob.perform_later(@deposit.id, activity_insight_oa_file.user.id)
+
+    flash[:notice] = I18n.t('activity_insight_oa_workflow.scholarsphere_deposit.success')
+    redirect_to activity_insight_oa_workflow_metadata_review_path
+  rescue ActiveRecord::RecordInvalid
+    flash[:alert] = @deposit.errors.full_messages.join(', ')
+    redirect_to activity_insight_oa_workflow_scholarsphere_deposit_path(publication.id)
   end
 end

--- a/app/controllers/activity_insight_oa_workflow/metadata_curation_controller.rb
+++ b/app/controllers/activity_insight_oa_workflow/metadata_curation_controller.rb
@@ -8,18 +8,18 @@ class ActivityInsightOAWorkflow::MetadataCurationController < ActivityInsightOAW
   def show
     @publication = Publication.ready_for_metadata_review.find(params[:publication_id])
   rescue ActiveRecord::RecordNotFound
-    flash[:notice] = 'This publication is not ready for metadata review.'
+    flash[:notice] = I18n.t('activity_insight_oa_workflow.metadata_curation_list.record_not_found')
     redirect_to activity_insight_oa_workflow_metadata_review_path
   end
 
   def create_scholarsphere_deposit
     publication = Publication.find(params[:publication_id])
     activity_insight_oa_file = publication.ai_file_for_deposit
-    authorship = Authorship.find_by(user: activity_insight_oa_file.user, 
+    authorship = Authorship.find_by(user: activity_insight_oa_file.user,
                                     publication: publication)
-    @deposit = ScholarsphereWorkDeposit.new_from_authorship(authorship, 
-                                                            rights: activity_insight_oa_file.license, 
-                                                            publisher_statement: activity_insight_oa_file.set_statement, 
+    @deposit = ScholarsphereWorkDeposit.new_from_authorship(authorship,
+                                                            rights: activity_insight_oa_file.license,
+                                                            publisher_statement: activity_insight_oa_file.set_statement,
                                                             embargoed_until: activity_insight_oa_file.embargo_date,
                                                             deposit_agreement: true,
                                                             deposited_at: Time.now,

--- a/app/controllers/activity_insight_oa_workflow/metadata_curation_controller.rb
+++ b/app/controllers/activity_insight_oa_workflow/metadata_curation_controller.rb
@@ -35,8 +35,5 @@ class ActivityInsightOAWorkflow::MetadataCurationController < ActivityInsightOAW
 
     flash[:notice] = I18n.t('activity_insight_oa_workflow.scholarsphere_deposit.success')
     redirect_to activity_insight_oa_workflow_metadata_review_path
-  rescue ActiveRecord::RecordInvalid
-    flash[:alert] = @deposit.errors.full_messages.join(', ')
-    redirect_to activity_insight_oa_workflow_scholarsphere_deposit_path(publication.id)
   end
 end

--- a/app/controllers/open_access_publications_controller.rb
+++ b/app/controllers/open_access_publications_controller.rb
@@ -141,8 +141,8 @@ class OpenAccessPublicationsController < OpenAccessWorkflowController
 
   def create_scholarsphere_deposit
     @authorship = Authorship.find_by(user: current_user, publication: publication)
-    extra_params = { authorship: @authorship, 
-                     deputy_user_id: current_user.deputy.id, 
+    extra_params = { authorship: @authorship,
+                     deputy_user_id: current_user.deputy.id,
                      deposit_workflow: 'Standard OA Workflow' }
     @deposit = ScholarsphereWorkDeposit.new(deposit_params.merge(extra_params))
     @deposit.file_uploads = []

--- a/app/controllers/open_access_publications_controller.rb
+++ b/app/controllers/open_access_publications_controller.rb
@@ -141,7 +141,9 @@ class OpenAccessPublicationsController < OpenAccessWorkflowController
 
   def create_scholarsphere_deposit
     @authorship = Authorship.find_by(user: current_user, publication: publication)
-    extra_params = { authorship: @authorship, deputy_user_id: current_user.deputy.id }
+    extra_params = { authorship: @authorship, 
+                     deputy_user_id: current_user.deputy.id, 
+                     deposit_workflow: 'Standard OA Workflow' }
     @deposit = ScholarsphereWorkDeposit.new(deposit_params.merge(extra_params))
     @deposit.file_uploads = []
 

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -713,6 +713,7 @@ class Publication < ApplicationRecord
       abstract.present? &&
       published_on.present? &&
       doi.present? &&
+      doi == DOISanitizer.new(doi).url &&
       !scholarsphere_upload_pending? &&
       !scholarsphere_upload_failed?
   end

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -706,6 +706,16 @@ class Publication < ApplicationRecord
       .first
   end
 
+  def can_deposit_to_scholarsphere?
+    ai_file_for_deposit.license.present? && 
+      title.present? && 
+      abstract.present? && 
+      published_on.present? && 
+      ai_file_for_deposit.file_download_location.present? && 
+      doi.present? &&
+      !scholarsphere_upload_pending?
+  end
+
   private
 
     def merge(publications_to_merge)

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -708,10 +708,10 @@ class Publication < ApplicationRecord
 
   def can_deposit_to_scholarsphere?
     ai_file_for_deposit.license.present? &&
+      ai_file_for_deposit.file_download_location.present? &&
       title.present? &&
       abstract.present? &&
       published_on.present? &&
-      ai_file_for_deposit.file_download_location.present? &&
       doi.present? &&
       !scholarsphere_upload_pending? &&
       !scholarsphere_upload_failed?

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -713,7 +713,8 @@ class Publication < ApplicationRecord
       published_on.present? &&
       ai_file_for_deposit.file_download_location.present? &&
       doi.present? &&
-      !scholarsphere_upload_pending?
+      !scholarsphere_upload_pending? &&
+      !scholarsphere_upload_failed?
   end
 
   private

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -707,11 +707,11 @@ class Publication < ApplicationRecord
   end
 
   def can_deposit_to_scholarsphere?
-    ai_file_for_deposit.license.present? && 
-      title.present? && 
-      abstract.present? && 
-      published_on.present? && 
-      ai_file_for_deposit.file_download_location.present? && 
+    ai_file_for_deposit.license.present? &&
+      title.present? &&
+      abstract.present? &&
+      published_on.present? &&
+      ai_file_for_deposit.file_download_location.present? &&
       doi.present? &&
       !scholarsphere_upload_pending?
   end

--- a/app/models/scholarsphere_work_deposit.rb
+++ b/app/models/scholarsphere_work_deposit.rb
@@ -96,6 +96,10 @@ class ScholarsphereWorkDeposit < ApplicationRecord
     file_uploads.map { |fu| File.new(fu.stored_file_path) }
   end
 
+  def standard_oa_workflow?
+    deposit_workflow == 'Standard OA Workflow'
+  end
+
   private
 
     def doi_format_is_valid

--- a/app/models/scholarsphere_work_deposit.rb
+++ b/app/models/scholarsphere_work_deposit.rb
@@ -25,6 +25,10 @@ class ScholarsphereWorkDeposit < ApplicationRecord
     ]
   end
 
+  def self.deposit_workflows
+    ['Activity Insight OA Workflow', 'Standard OA Workflow']
+  end
+
   attribute :deposit_agreement, :boolean
 
   after_initialize :set_status
@@ -35,6 +39,7 @@ class ScholarsphereWorkDeposit < ApplicationRecord
 
   validates :status, inclusion: { in: statuses }
   validates :rights, inclusion: { in: rights }
+  validates :deposit_workflow, inclusion: { in: deposit_workflows, allow_nil: true }
   validates :title, :description, :published_date, :rights, presence: true
   validate :at_least_one_file_upload
   validate :agreed_to_deposit_agreement
@@ -125,6 +130,7 @@ class ScholarsphereWorkDeposit < ApplicationRecord
         field(:status)
         field(:authorship)
         field(:title)
+        field(:deposit_workflow)
       end
     end
 end

--- a/app/services/scholarsphere_deposit_service.rb
+++ b/app/services/scholarsphere_deposit_service.rb
@@ -25,7 +25,7 @@ class ScholarsphereDepositService
       deposit.record_success(scholarsphere_publication_uri)
       profile = UserProfile.new(current_user)
       if deposit.standard_oa_workflow?
-        FacultyConfirmationsMailer.scholarsphere_deposit_confirmation(profile, deposit).deliver_now 
+        FacultyConfirmationsMailer.scholarsphere_deposit_confirmation(profile, deposit).deliver_now
       end
     else
       logger.info response.inspect

--- a/app/services/scholarsphere_deposit_service.rb
+++ b/app/services/scholarsphere_deposit_service.rb
@@ -24,7 +24,9 @@ class ScholarsphereDepositService
       scholarsphere_publication_uri = "#{ResearcherMetadata::Application.scholarsphere_base_uri}#{response_body['url']}"
       deposit.record_success(scholarsphere_publication_uri)
       profile = UserProfile.new(current_user)
-      FacultyConfirmationsMailer.scholarsphere_deposit_confirmation(profile, deposit).deliver_now
+      if deposit.standard_oa_workflow?
+        FacultyConfirmationsMailer.scholarsphere_deposit_confirmation(profile, deposit).deliver_now 
+      end
     else
       logger.info response.inspect
       raise DepositFailed.new(response.body)

--- a/app/views/activity_insight_oa_workflow/metadata_curation/show.html.erb
+++ b/app/views/activity_insight_oa_workflow/metadata_curation/show.html.erb
@@ -56,9 +56,9 @@
         </div>
         <% if @publication.can_deposit_to_scholarsphere? %>
           <div>
-            <%= link_to "Deposit to ScholarSphere", 
-                        activity_insight_oa_workflow_scholarsphere_deposit_path(@publication.id), 
-                        method: :post, 
+            <%= link_to "Deposit to ScholarSphere",
+                        activity_insight_oa_workflow_scholarsphere_deposit_path(@publication.id),
+                        method: :post,
                         class: 'btn btn-primary' %>
           </div>
         <% elsif @publication.scholarsphere_upload_pending? %>

--- a/app/views/activity_insight_oa_workflow/metadata_curation/show.html.erb
+++ b/app/views/activity_insight_oa_workflow/metadata_curation/show.html.erb
@@ -65,6 +65,10 @@
           <div>
             ScholarSphere upload pending...
           </div>
+        <% elsif @publication.scholarsphere_upload_failed? %>
+          <div>
+            ScholarSphere upload failed
+          </div>
         <% else %>
           <div>
             Insufficient metadata to upload to ScholarSphere

--- a/app/views/activity_insight_oa_workflow/metadata_curation/show.html.erb
+++ b/app/views/activity_insight_oa_workflow/metadata_curation/show.html.erb
@@ -39,9 +39,13 @@
         <li class='list-group-item'>
           <p class='float-left'>
             <strong>File Download:</strong>
-            <%= link_to @publication.ai_file_for_deposit.download_filename,
-                        activity_insight_oa_workflow_file_download_path(@publication.ai_file_for_deposit.id),
-                        target: '_blank' %>
+            <% if @publication.ai_file_for_deposit.file_download_location.present? %>
+              <%= link_to @publication.ai_file_for_deposit.download_filename,
+                          activity_insight_oa_workflow_file_download_path(@publication.ai_file_for_deposit.id),
+                          target: '_blank' %>
+            <% else %>
+              Not Found
+            <% end %>
           </p>
           <p class='float-right'><strong>Created On:</strong> <%= @publication.ai_file_for_deposit.created_at.to_date %></p>
         </li>

--- a/app/views/activity_insight_oa_workflow/metadata_curation/show.html.erb
+++ b/app/views/activity_insight_oa_workflow/metadata_curation/show.html.erb
@@ -47,10 +47,30 @@
         </li>
       </ul>
       <div class='card-footer'>
-        <%= link_to(
-          'Edit',
-          rails_admin.edit_path(model_name: :publication, id: @publication.id),
-          target: 'blank') %>
+      <div class='d-flex'>
+        <div class='mr-auto'>
+          <%= link_to(
+            'Edit',
+            rails_admin.edit_path(model_name: :publication, id: @publication.id),
+            target: 'blank') %>
+        </div>
+        <% if @publication.can_deposit_to_scholarsphere? %>
+          <div>
+            <%= link_to "Deposit to ScholarSphere", 
+                        activity_insight_oa_workflow_scholarsphere_deposit_path(@publication.id), 
+                        method: :post, 
+                        class: 'btn btn-primary' %>
+          </div>
+        <% elsif @publication.scholarsphere_upload_pending? %>
+          <div>
+            ScholarSphere upload pending...
+          </div>
+        <% else %>
+          <div>
+            Insufficient metadata to upload to ScholarSphere
+          </div>
+        <% end %>
+        </div>
       </div>
     </div>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -219,6 +219,9 @@ en:
       metadata_curation_description: Publications that have a file which can be deposited and that are ready for a final metadata check prior to submission to ScholarSphere.
       all_workflow_publications_title: All Publications
       all_workflow_publications_description: Troubleshooting list of all publications subject to workflow
+  activity_insight_oa_workflow:
+    scholarsphere_deposit:
+      success: The publication was successfully submitted for deposit to ScholarSphere.  You can check the status of the deposit from the "Scholarsphere work deposits" tab in the RailsAdmin dashboard.
 
   helpers:
     submit:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -222,6 +222,8 @@ en:
   activity_insight_oa_workflow:
     scholarsphere_deposit:
       success: The publication was successfully submitted for deposit to ScholarSphere.  You can check the status of the deposit from the "Scholarsphere work deposits" tab in the RailsAdmin dashboard.
+    metdata_curation_list:
+      record_not_found: This publication is not ready for metadata review.
 
   helpers:
     submit:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -222,7 +222,7 @@ en:
   activity_insight_oa_workflow:
     scholarsphere_deposit:
       success: The publication was successfully submitted for deposit to ScholarSphere.  You can check the status of the deposit from the "Scholarsphere work deposits" tab in the RailsAdmin dashboard.
-    metdata_curation_list:
+    metadata_curation_list:
       record_not_found: This publication is not ready for metadata review.
 
   helpers:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,7 @@ Rails.application.routes.draw do
     get '/metadata_review' => 'metadata_curation#index'
     get '/all_workflow_publications' => 'all_workflow_publications#index'
     get '/metadata_review/:publication_id' => 'metadata_curation#show', as: :review_publication_metadata
+    post '/metadata_review/:publication_id' => 'metadata_curation#create_scholarsphere_deposit', as: :scholarsphere_deposit
   end
 
   root to: 'public#home'

--- a/db/migrate/20231009192706_add_deposit_workflow_to_scholarsphere_work_deposits.rb
+++ b/db/migrate/20231009192706_add_deposit_workflow_to_scholarsphere_work_deposits.rb
@@ -1,0 +1,5 @@
+class AddDepositWorkflowToScholarsphereWorkDeposits < ActiveRecord::Migration[6.1]
+  def change
+    add_column :scholarsphere_work_deposits, :deposit_workflow, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_10_04_131322) do
+ActiveRecord::Schema.define(version: 2023_10_09_192706) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -53,16 +53,16 @@ ActiveRecord::Schema.define(version: 2023_10_04_131322) do
     t.string "file_download_location"
     t.boolean "downloaded"
     t.integer "user_id"
-    t.string "intellcont_id"
-    t.string "post_file_id"
-    t.boolean "exported_oa_status_to_activity_insight"
+    t.boolean "version_checked"
     t.datetime "permissions_last_checked_at"
     t.string "license"
     t.date "embargo_date"
     t.text "set_statement"
     t.boolean "checked_for_set_statement"
     t.boolean "checked_for_embargo_date"
-    t.boolean "version_checked"
+    t.string "intellcont_id"
+    t.string "post_file_id"
+    t.boolean "exported_oa_status_to_activity_insight"
     t.index ["publication_id"], name: "index_activity_insight_oa_files_on_publication_id"
     t.index ["user_id"], name: "index_activity_insight_oa_files_on_user_id"
   end
@@ -495,10 +495,11 @@ ActiveRecord::Schema.define(version: 2023_10_04_131322) do
     t.string "activity_insight_postprint_status"
     t.boolean "doi_verified"
     t.string "oa_workflow_state"
+    t.datetime "oa_status_last_checked_at"
     t.string "preferred_version"
     t.datetime "permissions_last_checked_at"
-    t.datetime "oa_status_last_checked_at"
     t.datetime "wrong_oa_version_notification_sent_at"
+    t.boolean "preferred_file_version_none_email_sent"
     t.index "date_part('year'::text, published_on)", name: "index_publications_on_published_on_year"
     t.index ["doi"], name: "index_publications_on_doi"
     t.index ["duplicate_publication_group_id"], name: "index_publications_on_duplicate_publication_group_id"
@@ -558,6 +559,7 @@ ActiveRecord::Schema.define(version: 2023_10_04_131322) do
     t.string "publisher"
     t.text "publisher_statement"
     t.bigint "deputy_user_id"
+    t.string "deposit_workflow"
     t.index ["authorship_id"], name: "index_scholarsphere_work_deposits_on_authorship_id"
     t.index ["deputy_user_id"], name: "index_scholarsphere_work_deposits_on_deputy_user_id"
   end

--- a/spec/component/models/publication_spec.rb
+++ b/spec/component/models/publication_spec.rb
@@ -4098,6 +4098,14 @@ describe Publication, type: :model do
       end
     end
 
+    context "when publication's doi is improperly formatted" do
+      before { publication.update_column :doi, 'invalid doi' }
+
+      it 'returns false' do
+        expect(publication.can_deposit_to_scholarsphere?).to be false
+      end
+    end
+
     context 'when publication has a scholarsphere_upload_pending' do
       before do
         auth = create(:authorship, publication: publication)

--- a/spec/component/models/scholarsphere_work_deposit_spec.rb
+++ b/spec/component/models/scholarsphere_work_deposit_spec.rb
@@ -24,6 +24,7 @@ describe 'the scholarsphere_work_deposits table', type: :model do
   it { is_expected.to have_db_column(:created_at).of_type(:datetime).with_options(null: false) }
   it { is_expected.to have_db_column(:updated_at).of_type(:datetime).with_options(null: false) }
   it { is_expected.to have_db_column(:deputy_user_id).of_type(:integer) }
+  it { is_expected.to have_db_column(:deposit_workflow).of_type(:string) }
 
   it { is_expected.to have_db_index(:authorship_id) }
   it { is_expected.to have_db_index :deputy_user_id }
@@ -62,6 +63,10 @@ describe ScholarsphereFileUpload, type: :model do
     https://rightsstatements.org/page/InC/1.0/
   }
   }
+
+  it { expect(subject).to validate_inclusion_of(:deposit_workflow).in_array ['Activity Insight OA Workflow',
+                                                                             'Standard OA Workflow',
+                                                                             nil] }
 
   it { is_expected.to validate_presence_of(:title) }
   it { is_expected.to validate_presence_of(:description) }
@@ -574,6 +579,24 @@ describe ScholarsphereFileUpload, type: :model do
 
       it 'is valid' do
         expect(dep).to be_valid
+      end
+    end
+  end
+
+  describe '#standard_oa_workflow?' do
+    context 'when deposit_workflow is "Standard OA Workflow"' do
+      let!(:deposit) { create(:scholarsphere_work_deposit, deposit_workflow: 'Standard OA Workflow') }
+
+      it 'returns true' do
+        expect(deposit.standard_oa_workflow?).to be true
+      end
+    end
+
+    context 'when deposit_workflow is not "Standard OA Workflow"' do
+      let!(:deposit) { create(:scholarsphere_work_deposit, deposit_workflow: 'Activity Insight OA Workflow') }
+
+      it 'returns true' do
+        expect(deposit.standard_oa_workflow?).to be false
       end
     end
   end

--- a/spec/component/services/scholarsphere_deposit_service_spec.rb
+++ b/spec/component/services/scholarsphere_deposit_service_spec.rb
@@ -8,7 +8,8 @@ describe ScholarsphereDepositService do
   let(:deposit) { double 'scholarsphere work deposit',
                          metadata: metadata,
                          files: files,
-                         record_success: nil }
+                         record_success: nil,
+                         standard_oa_workflow?: true }
   let(:metadata) { double 'metadata' }
   let(:files) { double 'files' }
   let(:ingest) { double 'scholarsphere client ingest', publish: response }
@@ -42,14 +43,16 @@ describe ScholarsphereDepositService do
         service.create
       end
 
-      context "when the deposit's deposit_workflow is 'Standard OA Workflow'" do
+      context "when deposit's #standard_oa_workflow? is true" do
         it 'sends a confirmation email to the user' do
           expect(email).to receive(:deliver_now)
           service.create
         end
       end
 
-      context "when the deposit's deposit_workflow is not 'Standard OA Workflow'" do
+      context "when deposit's #standard_oa_workflow? is false" do
+        before { allow(deposit).to receive(:standard_oa_workflow?).and_return false }
+
         it 'does not send a confirmation email to the user' do
           expect(email).not_to receive(:deliver_now)
           service.create

--- a/spec/component/services/scholarsphere_deposit_service_spec.rb
+++ b/spec/component/services/scholarsphere_deposit_service_spec.rb
@@ -42,9 +42,18 @@ describe ScholarsphereDepositService do
         service.create
       end
 
-      it 'sends a confirmation email to the user' do
-        expect(email).to receive(:deliver_now)
-        service.create
+      context "when the deposit's deposit_workflow is 'Standard OA Workflow'" do
+        it 'sends a confirmation email to the user' do
+          expect(email).to receive(:deliver_now)
+          service.create
+        end
+      end
+
+      context "when the deposit's deposit_workflow is not 'Standard OA Workflow'" do
+        it 'sends a confirmation email to the user' do
+          expect(email).not_to receive(:deliver_now)
+          service.create
+        end
       end
     end
 

--- a/spec/component/services/scholarsphere_deposit_service_spec.rb
+++ b/spec/component/services/scholarsphere_deposit_service_spec.rb
@@ -50,7 +50,7 @@ describe ScholarsphereDepositService do
       end
 
       context "when the deposit's deposit_workflow is not 'Standard OA Workflow'" do
-        it 'sends a confirmation email to the user' do
+        it 'does not send a confirmation email to the user' do
           expect(email).not_to receive(:deliver_now)
           service.create
         end

--- a/spec/integration/admin/activity_insight_oa_workflow/metadata_review/show_spec.rb
+++ b/spec/integration/admin/activity_insight_oa_workflow/metadata_review/show_spec.rb
@@ -70,6 +70,19 @@ describe 'Admin Metadata Review publication detail', type: :feature do
         end
       end
 
+      context 'when the file download location is not present' do
+        before do
+          pub2.ai_file_for_deposit.file_download_location.remove!
+          visit activity_insight_oa_workflow_review_publication_metadata_path(pub2)
+        end
+
+        it 'does not have a button to deposit to scholarsphere and indicates the metadata is incomplete' do
+          expect(page).to have_content 'Insufficient metadata to upload to ScholarSphere'
+          expect(page).to have_content 'Not Found'
+          expect(page).not_to have_button 'Deposit to ScholarSphere'
+        end
+      end
+
       context 'when the publication has a pending scholarsphere deposit' do
         before do
           auth = create(:authorship, publication: pub2)

--- a/spec/integration/admin/activity_insight_oa_workflow/metadata_review/show_spec.rb
+++ b/spec/integration/admin/activity_insight_oa_workflow/metadata_review/show_spec.rb
@@ -3,6 +3,7 @@
 require 'integration/integration_spec_helper'
 
 describe 'Admin Metadata Review publication detail', type: :feature do
+  let!(:user) { create :user }
   let!(:pub1) { create(:publication, title: 'Pub1', preferred_version: 'acceptedVersion') }
   let!(:pub2) {
     create(
@@ -10,6 +11,7 @@ describe 'Admin Metadata Review publication detail', type: :feature do
       preferred_version: 'acceptedVersion'
     )
   }
+  let!(:auth) { create(:authorship, publication: pub2, user: user) }
   let!(:aif2) {
     create(
       :activity_insight_oa_file,
@@ -19,7 +21,8 @@ describe 'Admin Metadata Review publication detail', type: :feature do
       set_statement: 'statement',
       embargo_date: Date.today,
       downloaded: true,
-      file_download_location: fixture_file_open('test_file.pdf')
+      file_download_location: fixture_file_open('test_file.pdf'),
+      user: user
     )
   }
 
@@ -30,14 +33,13 @@ describe 'Admin Metadata Review publication detail', type: :feature do
       it 'rescues the ActiveRecord::RecordNotFound error and returns to metadata review list with a flash message' do
         visit activity_insight_oa_workflow_review_publication_metadata_path(pub1)
         expect(page).to have_current_path activity_insight_oa_workflow_metadata_review_path
-        expect(page).to have_content 'his publication is not ready for metadata review.'
+        expect(page).to have_content 'This publication is not ready for metadata review.'
       end
     end
 
     context 'viewing the details for a publication that is ready for metadata review' do
-      before { visit activity_insight_oa_workflow_review_publication_metadata_path(pub2) }
-
       it 'shows the correct publication metadata and a link to edit the metadata' do
+        visit activity_insight_oa_workflow_review_publication_metadata_path(pub2)
         expect(page).to have_content pub2.title
         expect(page).to have_content pub2.secondary_title
         expect(page).to have_content pub2.doi
@@ -66,7 +68,7 @@ describe 'Admin Metadata Review publication detail', type: :feature do
 
         it 'does not have a button to deposit to scholarsphere and indicates the metadata is incomplete' do
           expect(page).to have_content 'Insufficient metadata to upload to ScholarSphere'
-          expect(page).not_to have_button 'Deposit to ScholarSphere'
+          expect(page).not_to have_link 'Deposit to ScholarSphere'
         end
       end
 
@@ -79,33 +81,57 @@ describe 'Admin Metadata Review publication detail', type: :feature do
         it 'does not have a button to deposit to scholarsphere and indicates the metadata is incomplete' do
           expect(page).to have_content 'Insufficient metadata to upload to ScholarSphere'
           expect(page).to have_content 'Not Found'
-          expect(page).not_to have_button 'Deposit to ScholarSphere'
+          expect(page).not_to have_link 'Deposit to ScholarSphere'
         end
       end
 
       context 'when the publication has a pending scholarsphere deposit' do
         before do
-          auth = create(:authorship, publication: pub2)
           create(:scholarsphere_work_deposit, authorship: auth, status: 'Pending')
           visit activity_insight_oa_workflow_review_publication_metadata_path(pub2)
         end
 
         it 'does not have a button to deposit to scholarsphere and indicates the deposit is pending' do
           expect(page).to have_content 'ScholarSphere upload pending...'
-          expect(page).not_to have_button 'Deposit to ScholarSphere'
+          expect(page).not_to have_link 'Deposit to ScholarSphere'
         end
       end
 
       context 'when the publication has a failed scholarsphere deposit' do
         before do
-          auth = create(:authorship, publication: pub2)
           create(:scholarsphere_work_deposit, authorship: auth, status: 'Failed')
           visit activity_insight_oa_workflow_review_publication_metadata_path(pub2)
         end
 
         it 'does not have a button to deposit to scholarsphere and indicates the deposit is failed' do
           expect(page).to have_content 'ScholarSphere upload failed'
-          expect(page).not_to have_button 'Deposit to ScholarSphere'
+          expect(page).not_to have_link 'Deposit to ScholarSphere'
+        end
+      end
+
+      context 'when the metadata is complete and the user clicks the button to deposit the publication to scholarsphere' do
+        context 'when there is no validation error' do
+          it 'submits the publication to be deposited to scholarsphere' do
+            visit activity_insight_oa_workflow_review_publication_metadata_path(pub2)
+            expect { click_link 'Deposit to ScholarSphere' }.to change { ScholarsphereWorkDeposit.count }.by 1
+            expect(page).to have_current_path activity_insight_oa_workflow_metadata_review_path
+            expect(page).to have_content 'The publication was successfully submitted for deposit to ScholarSphere.'
+            deposit = ScholarsphereWorkDeposit.last
+            expect(deposit.authorship_id).to eq auth.id
+            expect(deposit.status).to eq 'Pending' 
+            expect(deposit.error_message).to eq nil
+            expect(deposit.deposited_at).not_to be nil
+            expect(deposit.title).to eq pub2.title
+            expect(deposit.description).to eq pub2.abstract
+            expect(deposit.published_date).to eq pub2.published_on
+            expect(deposit.rights).to eq pub2.ai_file_for_deposit.license
+            expect(deposit.embargoed_until).to eq pub2.ai_file_for_deposit.embargo_date
+            expect(deposit.doi).to eq pub2.doi
+            expect(deposit.subtitle).to eq pub2.secondary_title
+            expect(deposit.publisher).to eq pub2.preferred_journal_title
+            expect(deposit.deputy_user_id).to eq nil
+            expect(deposit.deposit_workflow).to eq 'Activity Insight OA Workflow'
+          end
         end
       end
     end

--- a/spec/integration/admin/activity_insight_oa_workflow/metadata_review/show_spec.rb
+++ b/spec/integration/admin/activity_insight_oa_workflow/metadata_review/show_spec.rb
@@ -3,7 +3,7 @@
 require 'integration/integration_spec_helper'
 
 describe 'Admin Metadata Review publication detail', type: :feature do
-  let!(:user) { create :user }
+  let!(:user) { create(:user) }
   let!(:pub1) { create(:publication, title: 'Pub1', preferred_version: 'acceptedVersion') }
   let!(:pub2) {
     create(
@@ -113,14 +113,14 @@ describe 'Admin Metadata Review publication detail', type: :feature do
         context 'when there is no validation error' do
           it 'submits the publication to be deposited to scholarsphere' do
             visit activity_insight_oa_workflow_review_publication_metadata_path(pub2)
-            expect { click_link 'Deposit to ScholarSphere' }.to change { ScholarsphereWorkDeposit.count }.by 1
+            expect { click_link 'Deposit to ScholarSphere' }.to change(ScholarsphereWorkDeposit, :count).by 1
             expect(page).to have_current_path activity_insight_oa_workflow_metadata_review_path
             expect(page).to have_content 'The publication was successfully submitted for deposit to ScholarSphere.'
             deposit = ScholarsphereWorkDeposit.last
             expect(deposit.authorship_id).to eq auth.id
-            expect(deposit.status).to eq 'Pending' 
-            expect(deposit.error_message).to eq nil
-            expect(deposit.deposited_at).not_to be nil
+            expect(deposit.status).to eq 'Pending'
+            expect(deposit.error_message).to be_nil
+            expect(deposit.deposited_at).not_to be_nil
             expect(deposit.title).to eq pub2.title
             expect(deposit.description).to eq pub2.abstract
             expect(deposit.published_date).to eq pub2.published_on
@@ -129,7 +129,7 @@ describe 'Admin Metadata Review publication detail', type: :feature do
             expect(deposit.doi).to eq pub2.doi
             expect(deposit.subtitle).to eq pub2.secondary_title
             expect(deposit.publisher).to eq pub2.preferred_journal_title
-            expect(deposit.deputy_user_id).to eq nil
+            expect(deposit.deputy_user_id).to be_nil
             expect(deposit.deposit_workflow).to eq 'Activity Insight OA Workflow'
           end
         end

--- a/spec/integration/profiles/open_access_publications/edit_spec.rb
+++ b/spec/integration/profiles/open_access_publications/edit_spec.rb
@@ -350,6 +350,7 @@ describe 'visiting the page to edit the open acess status of a publication', typ
             expect(dep.embargoed_until).to eq Date.new((Date.today.year + 1), 5, 22)
             expect(dep.doi).to eq 'https://doi.org/10.1109/5.771073'
             expect(dep.publisher).to eq 'A Prestegious Journal'
+            expect(dep.deposit_workflow).to eq 'Standard OA Workflow'
           end
 
           it 'sends a request to deposit the publication in ScholarSphere' do
@@ -455,6 +456,7 @@ describe 'visiting the page to edit the open acess status of a publication', typ
           expect(dep.embargoed_until).to eq Date.new((Date.today.year + 1), 5, 22)
           expect(dep.doi).to eq 'https://doi.org/10.1109/5.771073'
           expect(dep.publisher).to eq 'A Prestegious Journal'
+          expect(dep.deposit_workflow).to eq 'Standard OA Workflow'
         end
 
         it 'shows the publication with the correct status in the profile publication list' do


### PR DESCRIPTION
Implements the button to send the publication metadata and its file over to ScholarSphere.

closes #716 