### PR TITLE
Adds offset and limit query params to organization publications endpoint

### DIFF
--- a/app/controllers/api/v1/organizations_controller.rb
+++ b/app/controllers/api/v1/organizations_controller.rb
@@ -8,7 +8,9 @@ module API::V1
 
     def publications
       org = api_token.all_organizations.visible.find(params[:id])
-      render json: API::V1::PublicationSerializer.new(org.all_publications)
+      render json: API::V1::PublicationSerializer.new(org.all_publications
+                                                         .offset(params[:offset])
+                                                         .limit(params[:limit]))
     end
   end
 end

--- a/public/api-docs/v1/swagger.yaml
+++ b/public/api-docs/v1/swagger.yaml
@@ -307,6 +307,21 @@ paths:
       required: true
       schema:
         type: integer
+    - name: offset
+      in: query
+      description: The number of items to skip before starting to collect the result
+        set
+      required: false
+      schema:
+        type: integer
+        format: int32
+    - name: limit
+      in: query
+      description: The numbers of items to return
+      required: false
+      schema:
+        type: integer
+        format: int32
     get:
       summary: Retrieve an organization's publications
       description: Returns publications that were authored by users while they were

--- a/spec/requests/api/v1/api_docs/organizations_spec.rb
+++ b/spec/requests/api/v1/api_docs/organizations_spec.rb
@@ -64,7 +64,27 @@ describe 'api/v1/organizations' do
 
   path '/v1/organizations/{id}/publications' do
     let(:id) { org.id }
-    parameter name: 'id', in: :path, type: :integer, description: 'The ID of an organization', required: true
+    parameter name: 'id',
+              in: :path,
+              type: :integer,
+              description: 'The ID of an organization',
+              required: true
+    parameter name: 'offset',
+              in: :query,
+              description: 'The number of items to skip before starting to collect the result set',
+              required: false,
+              schema: {
+                type: :integer,
+                format: :int32
+              }
+    parameter name: 'limit',
+              in: :query,
+              description: 'The numbers of items to return',
+              required: false,
+              schema: {
+                type: :integer,
+                format: :int32
+              }
 
     get "Retrieve an organization's publications" do
       description 'Returns publications that were authored by users while they were members of the organization'

--- a/spec/requests/api/v1/organizations_spec.rb
+++ b/spec/requests/api/v1/organizations_spec.rb
@@ -125,7 +125,7 @@ describe API::V1::OrganizationsController do
         context 'when the offset query parameter is passed' do
           let(:query_params) { '?offset=1' }
 
-          it "returns all the organization's visible publications" do
+          it "returns all the organization's visible publications after the offset number" do
             expect(json_response[:data].size).to eq(2)
             expect(json_response[:data].pluck(:attributes).pluck(:title)).to eq([pub_2.title, pub_3.title])
           end
@@ -134,7 +134,7 @@ describe API::V1::OrganizationsController do
         context 'when the limit query parameter is passed' do
           let(:query_params) { '?limit=1' }
 
-          it "returns all the organization's visible publications" do
+          it "returns a limited number of the organization's visible publications" do
             expect(json_response[:data].size).to eq(1)
             expect(json_response[:data].pluck(:attributes).pluck(:title)).to eq([pub_1.title])
           end
@@ -143,7 +143,7 @@ describe API::V1::OrganizationsController do
         context 'when the limit and offset query parameters are passed' do
           let(:query_params) { '?offset=1&limit=1' }
 
-          it "returns all the organization's visible publications" do
+          it "returns a limited number of the organization's visible publications after the offset number" do
             expect(json_response[:data].size).to eq(1)
             expect(json_response[:data].pluck(:attributes).pluck(:title)).to eq([pub_2.title])
           end

--- a/spec/requests/api/v1/organizations_spec.rb
+++ b/spec/requests/api/v1/organizations_spec.rb
@@ -103,8 +103,10 @@ describe API::V1::OrganizationsController do
 
     context 'when a valid authorization header value is included in the request' do
       context 'when given the ID of a visible organization' do
+        let(:query_params) { nil }
+
         before do
-          get "/v1/organizations/#{org.id}/publications", headers: headers
+          get "/v1/organizations/#{org.id}/publications#{query_params}", headers: headers
         end
 
         it 'updates the usage statistics on the API token' do
@@ -113,8 +115,38 @@ describe API::V1::OrganizationsController do
           expect(updated_token.last_used_at).not_to be_nil
         end
 
-        it "returns all the organization's visible publications" do
-          expect(json_response[:data].size).to eq(3)
+        context 'when no query parameters are passed' do
+          it "returns all the organization's visible publications" do
+            expect(json_response[:data].size).to eq(3)
+            expect(json_response[:data].pluck(:attributes).pluck(:title)).to eq([pub_1.title, pub_2.title, pub_3.title])
+          end
+        end
+
+        context 'when the offset query parameter is passed' do
+          let(:query_params) { '?offset=1' }
+
+          it "returns all the organization's visible publications" do
+            expect(json_response[:data].size).to eq(2)
+            expect(json_response[:data].pluck(:attributes).pluck(:title)).to eq([pub_2.title, pub_3.title])
+          end
+        end
+
+        context 'when the limit query parameter is passed' do
+          let(:query_params) { '?limit=1' }
+
+          it "returns all the organization's visible publications" do
+            expect(json_response[:data].size).to eq(1)
+            expect(json_response[:data].pluck(:attributes).pluck(:title)).to eq([pub_1.title])
+          end
+        end
+
+        context 'when the limit and offset query parameters are passed' do
+          let(:query_params) { '?offset=1&limit=1' }
+
+          it "returns all the organization's visible publications" do
+            expect(json_response[:data].size).to eq(1)
+            expect(json_response[:data].pluck(:attributes).pluck(:title)).to eq([pub_2.title])
+          end
         end
       end
 


### PR DESCRIPTION
closes #893 

I mention in the issue to do pagination.  I used the offset and limit parameters instead to give end users a little more flexibility.  I also think this is more commonly used with APIs.