### PR TITLE
Removes backfill

### DIFF
--- a/app/importers/activity_insight_importer.rb
+++ b/app/importers/activity_insight_importer.rb
@@ -205,7 +205,10 @@ class ActivityInsightImporter
 
           if activity_insight_file_location.blank?
             existing_file = ActivityInsightOAFile.find_by(intellcont_id: pub.activity_insight_id)
-            ActivityInsightOAFile.destroy_by(intellcont_id: pub.activity_insight_id) if existing_file.present?
+            if existing_file.present?
+              ActivityInsightOAFile.destroy_by(intellcont_id: pub.activity_insight_id)
+              pub_record.update! activity_insight_postprint_status: nil
+            end
           elsif activity_insight_file_location.present? && pub_record.can_receive_new_ai_oa_files?
             aif = pub_record.activity_insight_oa_files.find_by(location: activity_insight_file_location)
             if aif.blank?

--- a/app/importers/activity_insight_importer.rb
+++ b/app/importers/activity_insight_importer.rb
@@ -296,7 +296,7 @@ class ActivityInsightImporter
         doi: pub.doi
       }
       if pub.activity_insight_postprint_status.present?
-        attrs.merge!(activity_insight_postprint_status: pub.activity_insight_postprint_status)
+        attrs[:activity_insight_postprint_status] = pub.activity_insight_postprint_status
       end
       attrs
     end

--- a/app/importers/activity_insight_importer.rb
+++ b/app/importers/activity_insight_importer.rb
@@ -203,15 +203,6 @@ class ActivityInsightImporter
 
           activity_insight_file_location = pub.postprints&.first&.location
 
-          # This is only needed to backfill status in activity insight to 'In Progress' if the status
-          # in activity insight is currently blank
-          aif = pub_record.activity_insight_oa_files.find_by(location: activity_insight_file_location)
-          if aif.present? && pub.activity_insight_postprint_status.blank?
-            AiOAStatusExportJob.perform_later(aif.id, 'In Progress')
-            pub_record.activity_insight_postprint_status = 'In Progress'
-            pub_record.save!
-          end
-
           if activity_insight_file_location.blank?
             existing_file = ActivityInsightOAFile.find_by(intellcont_id: pub.activity_insight_id)
             ActivityInsightOAFile.destroy_by(intellcont_id: pub.activity_insight_id) if existing_file.present?

--- a/app/importers/activity_insight_importer.rb
+++ b/app/importers/activity_insight_importer.rb
@@ -263,7 +263,9 @@ class ActivityInsightImporter
 
     def always_update_pub_attrs(pub, pub_record)
       attrs = {}
-      attrs[:activity_insight_postprint_status] = pub.activity_insight_postprint_status
+      if pub.activity_insight_postprint_status.present?
+        attrs[:activity_insight_postprint_status] = pub.activity_insight_postprint_status
+      end
       if pub.status == 'Published'
         attrs[:status] = pub.status
       end
@@ -274,14 +276,13 @@ class ActivityInsightImporter
     end
 
     def pub_attrs(pub)
-      {
+      attrs = {
         title: pub.title,
         publication_type: pub.publication_type,
         journal_title: pub.journal_title,
         publisher_name: pub.publisher,
         secondary_title: pub.secondary_title,
         status: pub.status,
-        activity_insight_postprint_status: pub.activity_insight_postprint_status,
         volume: pub.volume,
         issue: pub.issue,
         edition: pub.edition,
@@ -294,6 +295,10 @@ class ActivityInsightImporter
         published_on: pub.published_on,
         doi: pub.doi
       }
+      if pub.activity_insight_postprint_status.present?
+        attrs.merge!(activity_insight_postprint_status: pub.activity_insight_postprint_status)
+      end
+      attrs
     end
 
     def ai_users

--- a/spec/component/importers/activity_insight_importer_spec.rb
+++ b/spec/component/importers/activity_insight_importer_spec.rb
@@ -1034,7 +1034,7 @@ describe ActivityInsightImporter do
                                      publisher_name: 'Existing Publisher 2',
                                      secondary_title: 'Existing Subtitle 2',
                                      status: 'Published',
-                                     activity_insight_postprint_status: 'Cannot Deposit',
+                                     activity_insight_postprint_status: 'In Progress',
                                      volume: '112',
                                      issue: '223',
                                      edition: '334',
@@ -1178,6 +1178,8 @@ describe ActivityInsightImporter do
 
             # testing that publication status does not revert to 'in press' when existing record status is 'published'
             expect(p5.status).to eq 'Published'
+            # testing that publication activity insight postprint status does not revert to nil when existing record status is 'In Progress'
+            expect(p5.activity_insight_postprint_status).to eq 'In Progress'
           end
 
           it 'groups duplicates of new publication records' do
@@ -1384,6 +1386,8 @@ describe ActivityInsightImporter do
                                            source_identifier: '92747188475').publication
             p4 = PublicationImport.find_by(source: 'Activity Insight',
                                            source_identifier: '190707482930').publication
+            p5 = PublicationImport.find_by(source: 'Activity Insight',
+                                           source_identifier: '271620739072').publication
 
             expect(p1.title).to eq 'First Test Publication With a Really Unique Title'
             expect(p1.publication_type).to eq 'Journal Article'
@@ -1464,6 +1468,9 @@ describe ActivityInsightImporter do
             expect(p4.visible).to be true
             expect(p4.updated_by_user_at).to be_nil
             expect(p4.doi).to eq 'https://doi.org/10.1186/s40543-020-00345-w'
+
+            # testing that publication activity insight postprint status does not revert to nil when existing record status is 'In Progress'
+            expect(p5.activity_insight_postprint_status).to eq 'In Progress'
           end
 
           it 'groups duplicates of new publication records' do

--- a/spec/component/importers/activity_insight_importer_spec.rb
+++ b/spec/component/importers/activity_insight_importer_spec.rb
@@ -5011,15 +5011,16 @@ describe ActivityInsightImporter do
                                publication: pub1, version: 'publishedVersion',
                                file_download_location: fixture_file_open('test_file.pdf'),
                                intellcont_id: '190706413568') }
-          let!(:pub1) { create(:publication) }
+          let!(:pub1) { create(:publication, activity_insight_postprint_status: 'In Progress') }
 
           let!(:file_download_directory1) { aif1.file_download_location.model_object_dir }
 
-          it 'deletes the ActivityInsightOAFile and downloaded file' do
+          it 'deletes the ActivityInsightOAFile and downloaded file and sets postprint status to nil' do
             importer.call
 
             expect(ActivityInsightOAFile.exists?(aif1.id)).to be false
             expect(File.exists?(file_download_directory1)).to be false
+            expect(pub1.reload.activity_insight_postprint_status).to be_nil
           end
         end
 

--- a/spec/fixtures/activity_insight_user_abc123.xml
+++ b/spec/fixtures/activity_insight_user_abc123.xml
@@ -580,7 +580,7 @@
       </INTELLCONT_FILE>
       <POST_FILE id="271620739080">
         <DOC/>
-        <ACCESIBLE>In Progress</ACCESIBLE>
+        <ACCESIBLE/>
       </POST_FILE>
       <DTM_EXPSUB/>
       <DTD_EXPSUB/>


### PR DESCRIPTION
Do not merge until the Activity Insight import has run in production after the recent release.

closes #898 