### PR TITLE
Replace return with next and message to stdout

### DIFF
--- a/lib/tasks/email_notifications.rake
+++ b/lib/tasks/email_notifications.rake
@@ -8,7 +8,10 @@ namespace :email_notifications do
 
   desc 'Send reminder emails about potential open access publications to applicable users up to the number passed as an argument (or the configured number as default)'
   task :send_capped_open_access_reminders, [:cap] => :environment do |_task, args|
-    return 'Notifications are turned off' if OANotificationSetting.not_active?
+    if OANotificationSetting.not_active?
+      $stdout.puts 'Notifications are turned off'
+      next
+    end
 
     cap = (args[:cap] || OANotificationSetting.email_cap).to_i
     OpenAccessNotifier.new.send_notifications_with_cap(cap)


### PR DESCRIPTION
`return` causes an error in rake tasks.  Using `next` and a message to STDOUT instead.