### PR TITLE
DOI not required for submission to ScholarSphere

### DIFF
--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -744,7 +744,6 @@ class Publication < ApplicationRecord
       title.present? &&
       abstract.present? &&
       published_on.present? &&
-      doi.present? &&
       doi == DOISanitizer.new(doi).url &&
       !scholarsphere_upload_pending? &&
       !scholarsphere_upload_failed?

--- a/spec/component/models/publication_spec.rb
+++ b/spec/component/models/publication_spec.rb
@@ -4149,8 +4149,8 @@ describe Publication, type: :model do
     context "when publication's doi is empty" do
       before { publication.update_column :doi, nil }
 
-      it 'returns false' do
-        expect(publication.can_deposit_to_scholarsphere?).to be false
+      it 'returns true' do
+        expect(publication.can_deposit_to_scholarsphere?).to be true
       end
     end
 


### PR DESCRIPTION
Removed requirement for DOI to submit a file to ScholarSphere from the AI OA Workflow

closes #933 