### PR TITLE
Fix double depositing scholarsphere deposits in AI workflow

### DIFF
--- a/app/controllers/activity_insight_oa_workflow/metadata_curation_controller.rb
+++ b/app/controllers/activity_insight_oa_workflow/metadata_curation_controller.rb
@@ -14,6 +14,10 @@ class ActivityInsightOAWorkflow::MetadataCurationController < ActivityInsightOAW
 
   def create_scholarsphere_deposit
     publication = Publication.find(params[:publication_id])
+    unless publication.can_deposit_to_scholarsphere?
+      flash[:warning] = I18n.t('activity_insight_oa_workflow.metadata_curation_list.cannot_be_deposited')
+      return redirect_to activity_insight_oa_workflow_metadata_review_path
+    end
     activity_insight_oa_file = publication.ai_file_for_deposit
     authorship = Authorship.find_by(user: activity_insight_oa_file.user,
                                     publication: publication)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -226,6 +226,7 @@ en:
       success: The publication was successfully submitted for deposit to ScholarSphere.  You can view the details of the deposit from the "Scholarsphere work deposits" tab in the RailsAdmin dashboard.
     metadata_curation_list:
       record_not_found: This publication is not ready for metadata review.
+      cannot_be_deposited: This publication cannot be deposited.
 
   helpers:
     submit:

--- a/spec/component/controllers/activity_insight_oa_workflow/metadata_curation_controller_spec.rb
+++ b/spec/component/controllers/activity_insight_oa_workflow/metadata_curation_controller_spec.rb
@@ -17,7 +17,7 @@ describe ActivityInsightOAWorkflow::MetadataCurationController, type: :controlle
 
       it 'redirects to metadata review list' do
         post :create_scholarsphere_deposit, params: { publication_id: publication.id }
-        expect(flash[:warning]).to eq "This publication cannot be deposited."
+        expect(flash[:warning]).to eq 'This publication cannot be deposited.'
         expect(response.redirect_url).to include activity_insight_oa_workflow_metadata_review_path
       end
     end

--- a/spec/component/controllers/activity_insight_oa_workflow/metadata_curation_controller_spec.rb
+++ b/spec/component/controllers/activity_insight_oa_workflow/metadata_curation_controller_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'component/component_spec_helper'
+
+describe ActivityInsightOAWorkflow::MetadataCurationController, type: :controller do
+  describe '#create_scholarsphere_deposit' do
+    let!(:user) { create(:user, is_admin: true) }
+    let!(:publication) { create(:sample_publication, :oa_publication, preferred_version: 'acceptedVersion') }
+    let!(:ai_oa_file) { create(:activity_insight_oa_file, publication: publication, version: 'acceptedVersion') }
+
+    context 'when publications cannot be deposited to scholarsphere' do
+      before do
+        allow(request.env['warden']).to receive(:authenticate!).and_return(user)
+        allow(controller).to receive(:current_user).and_return(user)
+        allow(publication).to receive(:scholarsphere_upload_pending?).and_return(true)
+      end
+
+      it 'redirects to metadata review list' do
+        post :create_scholarsphere_deposit, params: { publication_id: publication.id }
+        expect(flash[:warning]).to eq "This publication cannot be deposited."
+        expect(response.redirect_url).to include activity_insight_oa_workflow_metadata_review_path
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds controller level check that the file can be deposited.  This will prevent double clicks from creating multiple deposits.

fixes this comment https://github.com/psu-libraries/researcher-metadata/issues/755#issuecomment-1917971680