### PR TITLE
Fix broken ORCID test

### DIFF
--- a/spec/component/models/orcid_integration_spec.rb
+++ b/spec/component/models/orcid_integration_spec.rb
@@ -53,7 +53,7 @@ describe OrcidAPIClient do
 
     it 'successfully POSTs to ORCID and does not return an error' do
       post = client.post
-      expect(post.response.message).to eq 'Created'
+      expect(post.code).to eq 201 # Created code
       expect(post['location']).to include employment_path
       expect(employment_summary['department-name']).to eq json_resource['department-name']
       expect(employment_summary['role-title']).to eq json_resource['role-title']


### PR DESCRIPTION
Instead of testing that the response message is 'Created' just check for the 'Created' response code (201).  The api must've changed to stop sending the message.

This was just an issue with the test.  The actual ORCID client uses the response code in its logic.