### PR TITLE
Rescue Net::ReadTimeout when sending OA notifications.

### DIFF
--- a/app/models/open_access_notifier.rb
+++ b/app/models/open_access_notifier.rb
@@ -40,7 +40,7 @@ class OpenAccessNotifier
             p.authorships.find_by(user: user).record_open_access_notification
           end
         end
-      rescue Net::SMTPFatalError => e
+      rescue Net::SMTPFatalError, Net::ReadTimeout => e
         EmailError.create!(message: e.message, user: user)
       end
     end


### PR DESCRIPTION
Fixes part of #1018 .  Still need to figure out what is causing the Net::ReadTimeout.  Hopefully this will help, though.