### PR TITLE
add 'Flagged for Review' bucket to AI OA Workflow

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -49,6 +49,7 @@ RSpec/LeakyConstantDeclaration:
 RSpec/MultipleMemoizedHelpers:
   Exclude:
     - 'spec/component/models/user_spec.rb'
+    - 'spec/component/models/publication_spec.rb'
 
 Style/Semicolon:
   Exclude:

--- a/app/components/activity_insight_oa_dashboard_component.html.erb
+++ b/app/components/activity_insight_oa_dashboard_component.html.erb
@@ -124,6 +124,24 @@
     </div>
   <% end %>
   <br>
+  <% if flagged_for_review_count.nonzero? %>
+    <%= link_to activity_insight_oa_workflow_flagged_for_review_path, class: 'card-link' do %>
+      <div class='card' id='flagged-for-review-card'>
+        <div class='card-header'><strong><%= i18n('flagged_for_review_title') %></strong>
+          <span class='float-right text-large'><strong><%= flagged_for_review_count %></strong></span>
+        </div>
+        <div class='card-body'><%= i18n('flagged_for_review_description') %></div>
+      </div>
+    <% end %>
+  <% else %>
+    <div class='card text-muted' id='flagged-for-review-card'>
+      <div class='card-header'><strong><%= i18n('flagged_for_review_title') %></strong>
+        <span class='float-right text-large'>0</strong></span>
+      </div>
+      <div class='card-body'><%= i18n('flagged_for_review_description') %></div>
+    </div>
+  <% end %>
+  <br>
   <% if all_workflow_publications_count.nonzero? %>
     <%= link_to activity_insight_oa_workflow_all_workflow_publications_path, class: 'card-link' do %>
       <div class='card' id='all-workflow-publications-card'>

--- a/app/components/activity_insight_oa_dashboard_component.rb
+++ b/app/components/activity_insight_oa_dashboard_component.rb
@@ -29,6 +29,10 @@ class ActivityInsightOADashboardComponent < ViewComponent::Base
     Publication.ready_for_metadata_review.count
   end
 
+  def flagged_for_review_count
+    Publication.flagged_for_review.count
+  end
+
   def all_workflow_publications_count
     Publication.troubleshooting_list.count
   end

--- a/app/controllers/activity_insight_oa_workflow/flagged_for_review_controller.rb
+++ b/app/controllers/activity_insight_oa_workflow/flagged_for_review_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ActivityInsightOAWorkflow::FlaggedForReviewController < ActivityInsightOAWorkflowController
+  def index
+    @publications = Publication.flagged_for_review
+  end
+end

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -183,7 +183,7 @@ class Publication < ApplicationRecord
   }
   scope :nonflagged_activity_insight_oa_publication, -> {
     activity_insight_oa_publication
-    .where('flagged_for_review != true OR flagged_for_review IS NULL')
+      .where('flagged_for_review != true OR flagged_for_review IS NULL')
   }
   scope :troubleshooting_list, -> {
     activity_insight_oa_publication
@@ -249,7 +249,7 @@ class Publication < ApplicationRecord
       .where(preferred_version: nil)
   }
   scope :preferred_file_version_none, -> {
-    nonflagged_activity_insight_oa_publication
+                                        nonflagged_activity_insight_oa_publication
                                           .where(%{preferred_version = '#{NO_VERSION}'})
                                           .includes(:activity_insight_oa_files)
                                           .order('activity_insight_oa_files.created_at ASC')

--- a/app/views/activity_insight_oa_workflow/flagged_for_review/index.html.erb
+++ b/app/views/activity_insight_oa_workflow/flagged_for_review/index.html.erb
@@ -1,0 +1,39 @@
+<div class="container pt-4 pb-5">
+  <%= link_to '<< Back', activity_insight_oa_workflow_path %>
+  <h1 class="pb-3 pt-2">Flagged For Review</h1>
+  <table class="table">
+    <thead class='card-header'>
+      <tr>
+        <th>Author</th>
+        <th>Title</th>
+        <th>File Created At</th>
+        <th>Edit file in admin dashboard</th>
+      </tr>
+    </thead>
+    <tbody class='card-body'>
+      <% @publications.each do |p| %>
+        <tr id="<%= dom_id(p) %>">
+          <td rowspan="<%= p.activity_insight_oa_files.count %>">
+            <%= p.activity_insight_upload_user.webaccess_id %>
+          </td>
+          <td rowspan="<%= p.activity_insight_oa_files.count %>">
+            <%= link_to p.title.truncate(45),
+                    rails_admin.edit_path(model_name: :publication, id: p.id) + '#publication_doi',
+                    target: '_blank' %>
+          </td>
+          <% p.activity_insight_oa_files.each_with_index do |file, index| %>
+          <%= '<tr>'.html_safe unless index == 0 %>
+            <td>
+              <%= file.created_at.strftime("%m/%d/%Y") %>
+            </td>
+            <td class="file-name">
+                <%= link_to file.download_filename,
+                  rails_admin.edit_path(model_name: :activity_insight_oa_file, id: file.id),
+                  target: '_blank' %>
+            </td>
+        <% end %>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -221,6 +221,8 @@ en:
       permissions_curation_description: Publications with a file that can be deposited that does not have all required permissions metadata.
       metadata_curation_title: Review Publication Metadata
       metadata_curation_description: Publications that have a file which can be deposited and that are ready for a final metadata check prior to submission to ScholarSphere.
+      flagged_for_review_title: Flagged for Review
+      flagged_for_review_description: Publications that an admin user has flagged due to unusual issues with the publication or associated files
       all_workflow_publications_title: All Publications
       all_workflow_publications_description: Troubleshooting list of all publications subject to workflow
   activity_insight_oa_workflow:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,7 @@ Rails.application.routes.draw do
     get '/files/:activity_insight_oa_file_id/download' => 'files#download', as: :file_download
     get '/metadata_review' => 'metadata_curation#index'
     get '/all_workflow_publications' => 'all_workflow_publications#index'
+    get '/flagged_for_review' => 'flagged_for_review#index'
     get '/metadata_review/:publication_id' => 'metadata_curation#show', as: :review_publication_metadata
     post '/metadata_review/:publication_id' => 'metadata_curation#create_scholarsphere_deposit', as: :scholarsphere_deposit
   end

--- a/db/migrate/20241206152534_add_flagged_for_review_to_publication.rb
+++ b/db/migrate/20241206152534_add_flagged_for_review_to_publication.rb
@@ -1,0 +1,5 @@
+class AddFlaggedForReviewToPublication < ActiveRecord::Migration[7.2]
+  def change
+    add_column :publications, :flagged_for_review, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_10_12_202905) do
-
+ActiveRecord::Schema[7.2].define(version: 2024_12_06_152534) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
@@ -21,7 +20,7 @@ ActiveRecord::Schema.define(version: 2023_10_12_202905) do
     t.string "record_type", null: false
     t.bigint "record_id", null: false
     t.bigint "blob_id", null: false
-    t.datetime "created_at", null: false
+    t.datetime "created_at", precision: nil, null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
@@ -34,7 +33,7 @@ ActiveRecord::Schema.define(version: 2023_10_12_202905) do
     t.string "service_name", null: false
     t.bigint "byte_size", null: false
     t.string "checksum", null: false
-    t.datetime "created_at", null: false
+    t.datetime "created_at", precision: nil, null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
@@ -47,22 +46,22 @@ ActiveRecord::Schema.define(version: 2023_10_12_202905) do
   create_table "activity_insight_oa_files", force: :cascade do |t|
     t.string "location"
     t.bigint "publication_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "version"
     t.string "file_download_location"
     t.boolean "downloaded"
     t.integer "user_id"
-    t.datetime "permissions_last_checked_at"
+    t.string "intellcont_id"
+    t.string "post_file_id"
+    t.boolean "exported_oa_status_to_activity_insight"
+    t.datetime "permissions_last_checked_at", precision: nil
     t.string "license"
     t.date "embargo_date"
     t.text "set_statement"
     t.boolean "checked_for_set_statement"
     t.boolean "checked_for_embargo_date"
     t.boolean "version_checked"
-    t.string "intellcont_id"
-    t.string "post_file_id"
-    t.boolean "exported_oa_status_to_activity_insight"
     t.index ["publication_id"], name: "index_activity_insight_oa_files_on_publication_id"
     t.index ["user_id"], name: "index_activity_insight_oa_files_on_user_id"
   end
@@ -71,10 +70,10 @@ ActiveRecord::Schema.define(version: 2023_10_12_202905) do
     t.string "token", null: false
     t.string "app_name"
     t.string "admin_email"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.integer "total_requests", default: 0
-    t.datetime "last_used_at"
+    t.datetime "last_used_at", precision: nil
     t.boolean "write_access", default: false
     t.index ["token"], name: "index_api_tokens_on_token", unique: true
   end
@@ -83,15 +82,15 @@ ActiveRecord::Schema.define(version: 2023_10_12_202905) do
     t.integer "user_id", null: false
     t.integer "publication_id", null: false
     t.integer "author_number"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.boolean "visible_in_profile", default: true
     t.integer "position_in_profile"
     t.boolean "confirmed", default: true
     t.string "role"
-    t.datetime "open_access_notification_sent_at"
+    t.datetime "open_access_notification_sent_at", precision: nil
     t.string "orcid_resource_identifier"
-    t.datetime "updated_by_owner_at"
+    t.datetime "updated_by_owner_at", precision: nil
     t.boolean "claimed_by_user", default: false
     t.index ["publication_id"], name: "index_authorships_on_publication_id"
     t.index ["user_id"], name: "index_authorships_on_user_id"
@@ -101,8 +100,8 @@ ActiveRecord::Schema.define(version: 2023_10_12_202905) do
     t.integer "etd_id", null: false
     t.integer "user_id", null: false
     t.string "role", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["etd_id"], name: "index_committee_memberships_on_etd_id"
     t.index ["user_id"], name: "index_committee_memberships_on_user_id"
   end
@@ -110,8 +109,8 @@ ActiveRecord::Schema.define(version: 2023_10_12_202905) do
   create_table "contract_imports", force: :cascade do |t|
     t.integer "contract_id", null: false
     t.bigint "activity_insight_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["activity_insight_id"], name: "index_contract_imports_on_activity_insight_id", unique: true
     t.index ["contract_id"], name: "index_contract_imports_on_contract_id"
   end
@@ -125,8 +124,8 @@ ActiveRecord::Schema.define(version: 2023_10_12_202905) do
     t.integer "ospkey", null: false
     t.date "award_start_on"
     t.date "award_end_on"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.boolean "visible", default: false
     t.index ["ospkey"], name: "index_contracts_on_ospkey", unique: true
   end
@@ -137,8 +136,8 @@ ActiveRecord::Schema.define(version: 2023_10_12_202905) do
     t.string "middle_name"
     t.string "last_name"
     t.integer "position", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "role"
     t.bigint "user_id"
     t.index ["publication_id"], name: "index_contributor_names_on_publication_id"
@@ -150,24 +149,24 @@ ActiveRecord::Schema.define(version: 2023_10_12_202905) do
     t.integer "attempts", default: 0, null: false
     t.text "handler", null: false
     t.text "last_error"
-    t.datetime "run_at"
-    t.datetime "locked_at"
-    t.datetime "failed_at"
+    t.datetime "run_at", precision: nil
+    t.datetime "locked_at", precision: nil
+    t.datetime "failed_at", precision: nil
     t.string "locked_by"
     t.string "queue"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 
   create_table "deputy_assignments", force: :cascade do |t|
     t.bigint "primary_user_id"
     t.bigint "deputy_user_id"
-    t.datetime "deactivated_at"
+    t.datetime "deactivated_at", precision: nil
     t.boolean "is_active"
-    t.datetime "confirmed_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "confirmed_at", precision: nil
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.bigint "active_uniqueness_key", default: 0
     t.index ["deputy_user_id"], name: "index_deputy_assignments_on_deputy_user_id"
     t.index ["primary_user_id", "deputy_user_id", "active_uniqueness_key"], name: "index_deputy_assignments_on_unique_users_if_active", unique: true
@@ -175,8 +174,8 @@ ActiveRecord::Schema.define(version: 2023_10_12_202905) do
   end
 
   create_table "duplicate_publication_groups", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
   end
 
   create_table "education_history_items", force: :cascade do |t|
@@ -197,8 +196,8 @@ ActiveRecord::Schema.define(version: 2023_10_12_202905) do
     t.text "comments"
     t.integer "start_year"
     t.integer "end_year"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["activity_insight_identifier"], name: "index_education_history_items_on_activity_insight_identifier", unique: true
     t.index ["user_id"], name: "index_education_history_items_on_user_id"
   end
@@ -206,8 +205,8 @@ ActiveRecord::Schema.define(version: 2023_10_12_202905) do
   create_table "email_errors", force: :cascade do |t|
     t.integer "user_id", null: false
     t.text "message"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["user_id"], name: "index_email_errors_on_user_id"
   end
 
@@ -222,9 +221,9 @@ ActiveRecord::Schema.define(version: 2023_10_12_202905) do
     t.string "submission_type", null: false
     t.string "external_identifier", null: false
     t.string "access_level", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.datetime "updated_by_user_at"
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "updated_by_user_at", precision: nil
     t.index ["external_identifier"], name: "index_etds_on_external_identifier", unique: true
     t.index ["webaccess_id"], name: "index_etds_on_webaccess_id", unique: true
   end
@@ -237,8 +236,8 @@ ActiveRecord::Schema.define(version: 2023_10_12_202905) do
     t.string "doi"
     t.string "journal_title", null: false
     t.string "publisher"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.integer "internal_publication_waiver_id"
     t.bigint "deputy_user_id"
     t.index ["deputy_user_id"], name: "index_external_publication_waivers_on_deputy_user_id"
@@ -249,8 +248,8 @@ ActiveRecord::Schema.define(version: 2023_10_12_202905) do
   create_table "grants", force: :cascade do |t|
     t.text "wos_agency_name"
     t.string "wos_identifier"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.text "title"
     t.date "start_date"
     t.date "end_date"
@@ -268,10 +267,10 @@ ActiveRecord::Schema.define(version: 2023_10_12_202905) do
     t.string "importer_type", null: false
     t.string "error_type", null: false
     t.text "stacktrace", null: false
-    t.datetime "occurred_at", null: false
+    t.datetime "occurred_at", precision: nil, null: false
     t.jsonb "metadata"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.text "error_message", null: false
     t.index ["importer_type"], name: "index_importer_error_logs_on_importer_type"
   end
@@ -279,8 +278,8 @@ ActiveRecord::Schema.define(version: 2023_10_12_202905) do
   create_table "internal_publication_waivers", force: :cascade do |t|
     t.integer "authorship_id", null: false
     t.text "reason_for_waiver"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.bigint "deputy_user_id"
     t.index ["authorship_id"], name: "index_internal_publication_waivers_on_authorship_id"
     t.index ["deputy_user_id"], name: "index_internal_publication_waivers_on_deputy_user_id"
@@ -289,8 +288,8 @@ ActiveRecord::Schema.define(version: 2023_10_12_202905) do
   create_table "journals", force: :cascade do |t|
     t.string "pure_uuid"
     t.text "title", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.integer "publisher_id"
     t.index ["publisher_id"], name: "index_journals_on_publisher_id"
   end
@@ -300,8 +299,8 @@ ActiveRecord::Schema.define(version: 2023_10_12_202905) do
     t.string "title", null: false
     t.text "url", null: false
     t.text "description", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.date "published_on", null: false
     t.index ["url", "user_id"], name: "index_news_feed_items_on_url_and_user_id", unique: true
   end
@@ -309,23 +308,23 @@ ActiveRecord::Schema.define(version: 2023_10_12_202905) do
   create_table "non_duplicate_publication_group_memberships", force: :cascade do |t|
     t.integer "publication_id", null: false
     t.integer "non_duplicate_publication_group_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["non_duplicate_publication_group_id"], name: "index_ndpg_memberships_on_ndpg_id"
     t.index ["publication_id"], name: "index_ndpg_memberships_on_publication_id"
   end
 
   create_table "non_duplicate_publication_groups", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
   end
 
   create_table "oa_notification_settings", force: :cascade do |t|
     t.integer "singleton_guard"
     t.integer "email_cap"
     t.boolean "is_active"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["singleton_guard"], name: "index_oa_notification_settings_on_singleton_guard", unique: true
   end
 
@@ -336,13 +335,13 @@ ActiveRecord::Schema.define(version: 2023_10_12_202905) do
     t.string "license"
     t.date "oa_date"
     t.string "source"
-    t.datetime "source_updated_at"
+    t.datetime "source_updated_at", precision: nil
     t.string "url"
     t.string "landing_page_url"
     t.string "pdf_url"
     t.string "version"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.bigint "deputy_user_id"
     t.index ["deputy_user_id"], name: "index_open_access_locations_on_deputy_user_id"
     t.index ["publication_id"], name: "index_open_access_locations_on_publication_id"
@@ -351,8 +350,8 @@ ActiveRecord::Schema.define(version: 2023_10_12_202905) do
   create_table "organization_api_permissions", force: :cascade do |t|
     t.integer "api_token_id", null: false
     t.integer "organization_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["api_token_id"], name: "index_organization_api_permissions_on_api_token_id"
     t.index ["organization_id"], name: "index_organization_api_permissions_on_organization_id"
   end
@@ -364,8 +363,8 @@ ActiveRecord::Schema.define(version: 2023_10_12_202905) do
     t.string "pure_external_identifier"
     t.string "organization_type"
     t.integer "parent_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.integer "owner_id"
     t.index ["owner_id"], name: "index_organizations_on_owner_id"
     t.index ["parent_id"], name: "index_organizations_on_parent_id"
@@ -377,8 +376,8 @@ ActiveRecord::Schema.define(version: 2023_10_12_202905) do
     t.string "screening_type"
     t.string "name"
     t.string "location"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.bigint "activity_insight_id", null: false
     t.index ["activity_insight_id"], name: "index_performance_screenings_on_activity_insight_id", unique: true
     t.index ["performance_id"], name: "index_performance_screenings_on_performance_id"
@@ -395,9 +394,9 @@ ActiveRecord::Schema.define(version: 2023_10_12_202905) do
     t.string "scope"
     t.date "start_on"
     t.date "end_on"
-    t.datetime "updated_by_user_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "updated_by_user_at", precision: nil
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.boolean "visible", default: true
     t.bigint "activity_insight_id", null: false
     t.index ["activity_insight_id"], name: "index_performances_on_activity_insight_id", unique: true
@@ -409,8 +408,8 @@ ActiveRecord::Schema.define(version: 2023_10_12_202905) do
     t.integer "position"
     t.string "activity_insight_identifier"
     t.string "role"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.boolean "visible_in_profile", default: true
     t.integer "position_in_profile"
     t.index ["activity_insight_identifier"], name: "index_presentation_contributions_on_activity_insight_identifier", unique: true
@@ -434,10 +433,10 @@ ActiveRecord::Schema.define(version: 2023_10_12_202905) do
     t.text "abstract"
     t.text "comment"
     t.string "scope"
-    t.datetime "updated_by_user_at"
+    t.datetime "updated_by_user_at", precision: nil
     t.boolean "visible", default: true
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["activity_insight_identifier"], name: "index_presentations_on_activity_insight_identifier", unique: true
   end
 
@@ -445,9 +444,9 @@ ActiveRecord::Schema.define(version: 2023_10_12_202905) do
     t.integer "publication_id", null: false
     t.string "source", null: false
     t.string "source_identifier", null: false
-    t.datetime "source_updated_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "source_updated_at", precision: nil
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.boolean "auto_merged"
     t.index ["publication_id"], name: "index_publication_imports_on_publication_id"
     t.index ["source_identifier", "source"], name: "index_publication_imports_on_source_identifier_and_source", unique: true
@@ -457,15 +456,15 @@ ActiveRecord::Schema.define(version: 2023_10_12_202905) do
     t.integer "publication_id", null: false
     t.integer "tag_id", null: false
     t.float "rank"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["publication_id"], name: "index_publication_taggings_on_publication_id"
     t.index ["tag_id"], name: "index_publication_taggings_on_tag_id"
   end
 
   create_table "publications", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.text "title", null: false
     t.string "publication_type", null: false
     t.text "journal_title"
@@ -485,23 +484,24 @@ ActiveRecord::Schema.define(version: 2023_10_12_202905) do
     t.date "published_on"
     t.integer "total_scopus_citations"
     t.integer "duplicate_publication_group_id"
-    t.datetime "updated_by_user_at"
+    t.datetime "updated_by_user_at", precision: nil
     t.boolean "visible", default: true
-    t.datetime "open_access_button_last_checked_at"
+    t.datetime "open_access_button_last_checked_at", precision: nil
     t.integer "journal_id"
     t.boolean "exported_to_activity_insight"
     t.string "open_access_status"
-    t.datetime "unpaywall_last_checked_at"
+    t.datetime "unpaywall_last_checked_at", precision: nil
     t.string "activity_insight_postprint_status"
     t.boolean "doi_verified"
     t.string "oa_workflow_state"
     t.string "preferred_version"
-    t.datetime "permissions_last_checked_at"
-    t.datetime "oa_status_last_checked_at"
-    t.datetime "wrong_oa_version_notification_sent_at"
+    t.datetime "permissions_last_checked_at", precision: nil
+    t.datetime "oa_status_last_checked_at", precision: nil
+    t.datetime "wrong_oa_version_notification_sent_at", precision: nil
     t.boolean "preferred_file_version_none_email_sent"
     t.boolean "doi_error"
-    t.index "EXTRACT(year FROM published_on)", name: "index_publications_on_published_on_year"
+    t.boolean "flagged_for_review"
+    t.index "date_part('year'::text, published_on)", name: "index_publications_on_published_on_year"
     t.index ["doi"], name: "index_publications_on_doi"
     t.index ["duplicate_publication_group_id"], name: "index_publications_on_duplicate_publication_group_id"
     t.index ["issue"], name: "index_publications_on_issue"
@@ -513,15 +513,15 @@ ActiveRecord::Schema.define(version: 2023_10_12_202905) do
   create_table "publishers", force: :cascade do |t|
     t.string "pure_uuid"
     t.text "name", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
   end
 
   create_table "research_funds", force: :cascade do |t|
     t.integer "grant_id", null: false
     t.integer "publication_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["grant_id"], name: "index_research_funds_on_grant_id"
     t.index ["publication_id"], name: "index_research_funds_on_publication_id"
   end
@@ -529,16 +529,16 @@ ActiveRecord::Schema.define(version: 2023_10_12_202905) do
   create_table "researcher_funds", force: :cascade do |t|
     t.integer "grant_id", null: false
     t.integer "user_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["grant_id"], name: "index_researcher_funds_on_grant_id"
     t.index ["user_id"], name: "index_researcher_funds_on_user_id"
   end
 
   create_table "scholarsphere_file_uploads", force: :cascade do |t|
     t.string "file"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.integer "scholarsphere_work_deposit_id"
     t.index ["scholarsphere_work_deposit_id"], name: "scholarsphere_file_uploads_on_deposit_id"
   end
@@ -547,9 +547,9 @@ ActiveRecord::Schema.define(version: 2023_10_12_202905) do
     t.bigint "authorship_id"
     t.string "status"
     t.text "error_message"
-    t.datetime "deposited_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "deposited_at", precision: nil
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.text "title"
     t.text "description"
     t.date "published_date"
@@ -569,23 +569,23 @@ ActiveRecord::Schema.define(version: 2023_10_12_202905) do
   create_table "statistics_snapshots", force: :cascade do |t|
     t.integer "total_article_count"
     t.integer "open_access_article_count"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
   end
 
   create_table "tags", force: :cascade do |t|
     t.string "name", null: false
     t.string "source"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["name"], name: "index_tags_on_name"
   end
 
   create_table "user_contracts", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "contract_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["contract_id"], name: "index_user_contracts_on_contract_id"
     t.index ["user_id"], name: "index_user_contracts_on_user_id"
   end
@@ -596,9 +596,9 @@ ActiveRecord::Schema.define(version: 2023_10_12_202905) do
     t.string "source_identifier"
     t.string "position_title"
     t.boolean "primary"
-    t.datetime "updated_by_user_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "updated_by_user_at", precision: nil
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.date "started_on"
     t.date "ended_on"
     t.string "orcid_resource_identifier"
@@ -612,8 +612,8 @@ ActiveRecord::Schema.define(version: 2023_10_12_202905) do
   create_table "user_performances", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "performance_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "contribution"
     t.string "student_level"
     t.string "role_other"
@@ -630,13 +630,13 @@ ActiveRecord::Schema.define(version: 2023_10_12_202905) do
     t.string "first_name"
     t.string "middle_name"
     t.string "last_name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.boolean "is_admin", default: false
     t.string "webaccess_id", null: false
     t.string "pure_uuid"
     t.string "penn_state_identifier"
-    t.datetime "updated_by_user_at"
+    t.datetime "updated_by_user_at", precision: nil
     t.boolean "show_all_publications", default: true
     t.boolean "show_all_contracts", default: false
     t.integer "scopus_h_index"
@@ -661,11 +661,11 @@ ActiveRecord::Schema.define(version: 2023_10_12_202905) do
     t.string "orcid_access_token_scope"
     t.integer "orcid_access_token_expires_in"
     t.string "authenticated_orcid_identifier"
-    t.datetime "open_access_notification_sent_at"
+    t.datetime "open_access_notification_sent_at", precision: nil
     t.string "provider"
     t.string "uid"
     t.jsonb "psu_identity"
-    t.datetime "psu_identity_updated_at"
+    t.datetime "psu_identity_updated_at", precision: nil
     t.boolean "suppress_oa_reminders", default: false
     t.index ["activity_insight_identifier"], name: "index_users_on_activity_insight_identifier", unique: true
     t.index ["first_name"], name: "index_users_on_first_name"

--- a/spec/component/components/activity_insight_oa_dashboard_component_spec.rb
+++ b/spec/component/components/activity_insight_oa_dashboard_component_spec.rb
@@ -278,6 +278,31 @@ RSpec.describe ActivityInsightOADashboardComponent, type: :component do
     end
   end
 
+  context 'when no publications are flagged for review' do
+    let!(:oal) { create(:open_access_location, publication: pub2, source: Source::UNPAYWALL) }
+    let!(:pub1) { create(:publication, doi_verified: true) }
+    let!(:pub2) { create(:publication, doi_verified: nil) }
+
+    it 'renders a muted card with no link' do
+      render_inline(described_class.new)
+      expect(page.find_by_id('flagged-for-review-card').to_json).to include('text-muted')
+      expect(page.find_by_id('flagged-for-review-card').text).to include('0')
+      expect(rendered_content).not_to have_link(href: '/activity_insight_oa_workflow/flagged_for_review')
+    end
+  end
+
+  context 'when publications are flagged for review' do
+    let!(:pub1) { create(:publication, flagged_for_review: true) }
+    let!(:pub2) { create(:publication, doi_verified: nil) }
+
+    it 'renders the flagged for review card with a link and the number of publications in the corner' do
+      render_inline(described_class.new)
+      expect(page.find_by_id('flagged-for-review-card').to_json).not_to include('text-muted')
+      expect(page.find_by_id('flagged-for-review-card').text).to include('1')
+      expect(rendered_content).to have_link(href: '/activity_insight_oa_workflow/flagged_for_review')
+    end
+  end
+
   context 'when there are publications in the workflow' do
     let!(:pub1) { create(:publication) }
     let!(:pub2) { create(:publication) }

--- a/spec/component/models/publication_spec.rb
+++ b/spec/component/models/publication_spec.rb
@@ -656,6 +656,12 @@ describe Publication, type: :model do
                           doi_error: true,
                           publication_type: 'Academic Journal Article')
     }
+    let!(:pub2c) { create(:publication,
+                          title: 'pub2c',
+                          doi_verified: false,
+                          flagged_for_review: true,
+                          publication_type: 'Academic Journal Article')
+    }
     let!(:pub3) { create(:publication,
                          title: 'pub3',
                          doi_verified: true,
@@ -669,6 +675,14 @@ describe Publication, type: :model do
                          oa_workflow_state: nil,
                          preferred_version: 'acceptedVersion',
                          publication_type: 'Journal Article')
+    }
+    let!(:pub4b) { create(:publication,
+                          title: 'pub4b',
+                          doi_verified: nil,
+                          oa_workflow_state: nil,
+                          flagged_for_review: true,
+                          preferred_version: 'acceptedVersion',
+                          publication_type: 'Journal Article')
     }
     let!(:pub5) { create(:publication,
                          title: 'pub5',
@@ -693,6 +707,11 @@ describe Publication, type: :model do
                           title: 'pub8b',
                           doi_verified: true,
                           open_access_status: 'hybrid')
+    }
+    let!(:pub8c) { create(:publication,
+                          title: 'pub8c',
+                          flagged_for_review: true,
+                          doi_verified: true)
     }
     let!(:pub9a) { create(:publication,
                           title: 'pub9a',
@@ -754,10 +773,23 @@ describe Publication, type: :model do
                           doi_verified: true,
                           permissions_last_checked_at: DateTime.now)
     }
+    let!(:pub9k) { create(:publication,
+                          title: 'pub9k',
+                          preferred_version: nil,
+                          flagged_for_review: true,
+                          doi_verified: true,
+                          permissions_last_checked_at: DateTime.now)
+    }
     let!(:pub10) { create(:publication,
                           title: 'pub10',
                           preferred_version: 'acceptedVersion',
                           doi_verified: true)
+    }
+    let!(:pub10b) { create(:publication,
+                           title: 'pub10b',
+                           flagged_for_review: true,
+                           preferred_version: 'acceptedVersion',
+                           doi_verified: true)
     }
     let!(:pub11) { create(:publication,
                           title: 'pub11',
@@ -771,6 +803,20 @@ describe Publication, type: :model do
                            preferred_version: 'None',
                            doi_verified: nil)
     }
+    let!(:pub11c) { create(:publication,
+                           title: 'pub11c',
+                           publication_type: 'Journal Article',
+                           preferred_version: 'acceptedVersion',
+                           flagged_for_review: true,
+                           doi_verified: nil)
+    }
+    let!(:pub11d) { create(:publication,
+                           title: 'pub11d',
+                           publication_type: 'Journal Article',
+                           preferred_version: 'None',
+                           flagged_for_review: true,
+                           doi_verified: nil)
+    }
     let!(:pub12) { create(:publication,
                           title: 'pub12',
                           publication_type: 'Journal Article',
@@ -782,6 +828,13 @@ describe Publication, type: :model do
                            publication_type: 'Journal Article',
                            preferred_version: 'acceptedVersion',
                            doi_verified: true)
+    }
+    let!(:pub12c) { create(:publication,
+                           title: 'pub12c',
+                           flagged_for_review: true,
+                           publication_type: 'Journal Article',
+                           preferred_version: 'acceptedVersion',
+                           doi_verified: nil)
     }
     let!(:pub13a) { create(:publication,
                            title: 'pub13a',
@@ -857,6 +910,12 @@ describe Publication, type: :model do
                            preferred_version: 'acceptedVersion',
                            open_access_status: nil)
     }
+    let!(:pub13o) { create(:publication,
+                           title: 'pub13o',
+                           flagged_for_review: true,
+                           publication_type: 'Journal Article',
+                           preferred_version: 'Published or Accepted')
+    }
     let!(:pub14a) { create(:publication,
                            title: 'pub14a',
                            publication_type: 'Journal Article',
@@ -886,14 +945,25 @@ describe Publication, type: :model do
                            preferred_version: 'None',
                            preferred_file_version_none_email_sent: true)
     }
+    let!(:pub14e) { create(:publication,
+                           title: 'pub14e',
+                           flagged_for_review: true,
+                           publication_type: 'Journal Article',
+                           doi_verified: true,
+                           oa_status_last_checked_at: 1.minute.ago,
+                           preferred_version: 'Published or Accepted')
+    }
 
     let!(:activity_insight_oa_file1) { create(:activity_insight_oa_file, publication: pub2) }
     let!(:activity_insight_oa_file1b) { create(:activity_insight_oa_file, publication: pub2b) }
+    let!(:activity_insight_oa_file1c) { create(:activity_insight_oa_file, publication: pub2c) }
     let!(:activity_insight_oa_file2) { create(:activity_insight_oa_file, publication: pub3) }
     let!(:activity_insight_oa_file3) { create(:activity_insight_oa_file, publication: pub4) }
+    let!(:activity_insight_oa_file3b) { create(:activity_insight_oa_file, publication: pub4b) }
     let!(:activity_insight_oa_file4) { create(:activity_insight_oa_file, publication: pub6, version: 'unknown') }
     let!(:activity_insight_oa_file5) { create(:activity_insight_oa_file, publication: pub7) }
     let!(:activity_insight_oa_file6) { create(:activity_insight_oa_file, publication: pub8) }
+    let!(:activity_insight_oa_file6c) { create(:activity_insight_oa_file, publication: pub8c) }
     let!(:activity_insight_oa_file7a) { create(:activity_insight_oa_file, publication: pub9a) }
     let!(:activity_insight_oa_file7b) { create(:activity_insight_oa_file, publication: pub9b) }
     let!(:activity_insight_oa_file7c) { create(:activity_insight_oa_file, publication: pub9c) }
@@ -904,13 +974,19 @@ describe Publication, type: :model do
     let!(:activity_insight_oa_file7h) { create(:activity_insight_oa_file, publication: pub9h) }
     let!(:activity_insight_oa_file7i) { create(:activity_insight_oa_file, publication: pub9i) }
     let!(:activity_insight_oa_file7j) { create(:activity_insight_oa_file, publication: pub9j) }
+    let!(:activity_insight_oa_file7k) { create(:activity_insight_oa_file, publication: pub9k) }
     let!(:activity_insight_oa_file8) { create(:activity_insight_oa_file, publication: pub10) }
+    let!(:activity_insight_oa_file8b) { create(:activity_insight_oa_file, publication: pub10b) }
     let!(:activity_insight_oa_file9) { create(:activity_insight_oa_file, publication: pub11, version: 'unknown') }
     let!(:activity_insight_oa_file9b) { create(:activity_insight_oa_file, publication: pub11b, version: 'unknown') }
+    let!(:activity_insight_oa_file9c) { create(:activity_insight_oa_file, publication: pub11c, version: 'unknown') }
     let!(:activity_insight_oa_file10) { create(:activity_insight_oa_file, publication: pub11, version: 'publishedVersion') }
+    let!(:activity_insight_oa_file10d) { create(:activity_insight_oa_file, publication: pub11d, version: 'publishedVersion') }
     let!(:activity_insight_oa_file11) { create(:activity_insight_oa_file, publication: pub4, version: 'unknown') }
     let!(:activity_insight_oa_file12) { create(:activity_insight_oa_file, publication: pub12, version: 'publishedVersion') }
     let!(:activity_insight_oa_file12b) { create(:activity_insight_oa_file, publication: pub12b, version: 'notArticleFile') }
+    let!(:activity_insight_oa_file12c) { create(:activity_insight_oa_file, publication: pub12c, version: 'publishedVersion') }
+    let!(:activity_insight_oa_file13o) { create(:activity_insight_oa_file, publication: pub13o) }
     let!(:activity_insight_oa_file13a_1) {
       create(
         :activity_insight_oa_file,
@@ -1014,7 +1090,7 @@ describe Publication, type: :model do
         version: 'acceptedVersion'
       )
     }
-
+    let!(:activity_insight_oa_file14e) { create(:activity_insight_oa_file, publication: pub14e) }
     let!(:open_access_location5) { create(:open_access_location, publication: pub5) }
     let!(:open_access_location12) { create(:open_access_location, publication: pub12, source: Source::UNPAYWALL) }
     let!(:open_access_location13m_1) { create(:open_access_location, publication: pub13m, source: Source::SCHOLARSPHERE) }
@@ -1025,10 +1101,13 @@ describe Publication, type: :model do
         expect(described_class.activity_insight_oa_publication).to match_array [
           pub2,
           pub2b,
+          pub2c,
           pub3,
           pub4,
+          pub4b,
           pub6,
           pub8,
+          pub8c,
           pub9a,
           pub9b,
           pub9c,
@@ -1039,18 +1118,25 @@ describe Publication, type: :model do
           pub9h,
           pub9i,
           pub9j,
+          pub9k,
           pub10,
+          pub10b,
           pub11,
           pub11b,
+          pub11c,
+          pub11d,
           pub12,
           pub12b,
+          pub12c,
           pub13a,
           pub13b,
           pub13c,
           pub13d,
+          pub13o,
           pub14a,
           pub14b,
-          pub14c
+          pub14c,
+          pub14e
         ]
       end
     end
@@ -1065,13 +1151,18 @@ describe Publication, type: :model do
       it 'returns activity_insight_oa_publications whose doi_verified is nil' do
         expect(described_class.needs_doi_verification).to match_array [
           pub4,
+          pub4b,
           pub11,
           pub11b,
+          pub11c,
+          pub11d,
           pub12,
+          pub12c,
           pub13a,
           pub13b,
           pub13c,
-          pub13d
+          pub13d,
+          pub13o
         ]
       end
     end
@@ -1092,6 +1183,7 @@ describe Publication, type: :model do
       it 'returns activity_insight_oa_publications with a verified doi that have not been checked' do
         expect(described_class.needs_oa_metadata_search).to match_array [
           pub8,
+          pub8c,
           pub9a,
           pub9b,
           pub9c,
@@ -1102,7 +1194,9 @@ describe Publication, type: :model do
           pub9h,
           pub9i,
           pub9j,
+          pub9k,
           pub10,
+          pub10b,
           pub12b
         ]
       end
@@ -1110,13 +1204,13 @@ describe Publication, type: :model do
 
     describe '.needs_permissions_check' do
       it 'returns activity_insight_oa_publications that have not been checked for a preferred version' do
-        expect(described_class.needs_permissions_check).to match_array [pub8]
+        expect(described_class.needs_permissions_check).to match_array [pub8, pub8c]
       end
     end
 
     describe '.needs_manual_preferred_version_check' do
       it 'returns activity_insight_oa_publications that have had their permissions checked but are still missing permissions data' do
-        expect(described_class.needs_manual_preferred_version_check).to match_array [pub9b]
+        expect(described_class.needs_manual_preferred_version_check).to match_array [pub9b, pub9k]
       end
     end
 
@@ -1139,6 +1233,12 @@ describe Publication, type: :model do
       # SQL query for this scope.
       it 'returns activity_insight_oa_publications with a preferred version and a downloaded file that matches the preferred version' do
         expect(described_class.ready_for_metadata_review).to match_array [pub13b, pub13c]
+      end
+    end
+
+    describe '.flagged_for_review' do
+      it 'returns activity_insight_oa_publications that have been flagged for review' do
+        expect(described_class.flagged_for_review).to match_array [pub2c, pub4b, pub8c, pub9k, pub10b, pub11c, pub11d, pub12c, pub13o, pub14e]
       end
     end
   end

--- a/spec/integration/admin/activity_insight_oa_workflow/flagged_for_review_spec.rb
+++ b/spec/integration/admin/activity_insight_oa_workflow/flagged_for_review_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'integration/integration_spec_helper'
+
+describe 'Review dashboard for flagged publications', type: :feature do
+  let!(:aif1) { create(:activity_insight_oa_file, publication: pub1, created_at: Time.new(2020, 1, 1, 0, 0, 0)) }
+  let!(:aif2) { create(:activity_insight_oa_file, publication: pub2, created_at: Time.new(2023, 1, 1, 0, 0, 0)) }
+  let!(:aif3) { create(:activity_insight_oa_file, publication: pub3, created_at: Time.new(2010, 1, 1, 0, 0, 0)) }
+  let!(:pub1) { create(:publication, title: 'Title 1', flagged_for_review: true) }
+  let!(:pub2) { create(:publication, title: 'Title 2', flagged_for_review: true) }
+  let!(:pub3) { create(:publication, title: 'Title 3', flagged_for_review: true) }
+
+  before do
+    authenticate_admin_user
+    visit activity_insight_oa_workflow_flagged_for_review_path
+  end
+
+  describe 'listing all publications flagged for review' do
+    it 'show a table with header and the proper data for the publications in the table' do
+      expect(page).to have_text('Author')
+      expect(page).to have_text(pub1.activity_insight_upload_user.webaccess_id)
+      expect(page).to have_text('Title')
+      expect(page).to have_link(pub1.title)
+      expect(page).to have_text('File Created At')
+      expect(page).to have_text('Edit file in admin dashboard')
+      expect(page).to have_css('tr').exactly(4).times
+      expect(page).to have_link(aif1.download_filename)
+    end
+
+    it 'orders the publications by file creation date' do
+      within(:xpath, '//table/tbody/tr[1]/td[2]') do
+        expect(page).to have_content('Title 3')
+      end
+      within(:xpath, '//table/tbody/tr[2]/td[2]') do
+        expect(page).to have_content('Title 1')
+      end
+      within(:xpath, '//table/tbody/tr[3]/td[2]') do
+        expect(page).to have_content('Title 2')
+      end
+    end
+  end
+
+  describe 'clicking "<< Back"' do
+    it 'redirects to the OA Workflow Dashboard' do
+      click_link '<< Back'
+      expect(page).to have_current_path activity_insight_oa_workflow_path
+    end
+  end
+
+  describe 'clicking a link to edit a publication' do
+    it "redirects to that publication's edit page" do
+      click_link pub1.title
+      expect(page).to have_current_path rails_admin.edit_path(model_name: :publication, id: pub1.id)
+    end
+  end
+end


### PR DESCRIPTION
Fixes #978 

Adds all publications with `flagged_for_review == true` to new bucket and removes them from all other buckets.

With the rails upgrade, running `db:migrate` made changes in the schema to all timestamped attributes. Default precision is now 6 so declaring that is not necessary and anything that's not 6 needs to specify precision nil.