### PR TITLE
ensure doi matching is not case sensitive

### DIFF
--- a/app/models/duplicate_publication_group.rb
+++ b/app/models/duplicate_publication_group.rb
@@ -24,13 +24,13 @@ class DuplicatePublicationGroup < ApplicationRecord
 
   def self.group_duplicates_of(publication)
     duplicates = if publication.imports.count == 1 && publication.imports.find { |i| i.source == 'Activity Insight' }
-                   Publication.where(%{(similarity(CONCAT(title, secondary_title), ?) >= 0.6 AND (? BETWEEN EXTRACT(YEAR FROM published_on)-2 AND EXTRACT(YEAR FROM published_on)+2 OR published_on IS NULL)) OR (doi = ? AND doi != '')},
+                   Publication.where(%{(similarity(CONCAT(title, secondary_title), ?) >= 0.6 AND (? BETWEEN EXTRACT(YEAR FROM published_on)-2 AND EXTRACT(YEAR FROM published_on)+2 OR published_on IS NULL)) OR (doi ILIKE ? AND doi != '')},
                                      "#{publication.title}#{publication.secondary_title}",
                                      publication.published_on.try(:year),
                                      publication.doi)
                      .where.not(id: publication.non_duplicate_groups.map { |g| g.memberships.map(&:publication_id) }.flatten).or(Publication.where(id: publication.id))
                  else
-                   Publication.where(%{(similarity(CONCAT(title, secondary_title), ?) >= 0.6 AND (? BETWEEN EXTRACT(YEAR FROM published_on)-2 AND EXTRACT(YEAR FROM published_on)+2 OR published_on IS NULL) AND (doi = ? OR doi = '' OR doi IS NULL)) OR (doi = ? AND doi != '')},
+                   Publication.where(%{(similarity(CONCAT(title, secondary_title), ?) >= 0.6 AND (? BETWEEN EXTRACT(YEAR FROM published_on)-2 AND EXTRACT(YEAR FROM published_on)+2 OR published_on IS NULL) AND (doi ILIKE ? OR doi = '' OR doi IS NULL)) OR (doi ILIKE ? AND doi != '')},
                                      "#{publication.title}#{publication.secondary_title}",
                                      publication.published_on.try(:year),
                                      publication.doi,

--- a/spec/component/models/duplicate_publication_group_spec.rb
+++ b/spec/component/models/duplicate_publication_group_spec.rb
@@ -648,6 +648,26 @@ describe DuplicatePublicationGroup, type: :model do
       end
     end
 
+    context 'given a publication with the same DOI as another publication but with different doi casing, titles, and publication date' do
+      let!(:p1) { create(:publication,
+                         title: 'A Generic Title',
+                         published_on: Date.new(2000, 1, 1),
+                         doi: 'https://doi.org/10.000/some-doi-22357634') }
+
+      let!(:p2) { create(:publication,
+                         title: 'A Different One',
+                         published_on: Date.new(2003, 1, 1),
+                         doi: 'https://doi.org/10.000/some-DOI-22357634') }
+
+      it 'groups the publications' do
+        described_class.group_duplicates_of(p1)
+        group = p1.reload.duplicate_group
+
+        expect(group).not_to be_nil
+        expect(p2.reload.duplicate_group).to eq group
+      end
+    end
+
     context 'given a publication with different DOIs. titles, and publication years' do
       let!(:p1) { create(:publication,
                          title: 'A Generic Title',
@@ -976,6 +996,30 @@ describe DuplicatePublicationGroup, type: :model do
                          title: 'A Different Title',
                          published_on: Date.new(1986, 1, 1),
                          doi: 'https://doi.org/10.000/some-doi-457472486') }
+
+      let!(:p2_import_1) { create(:publication_import,
+                                  source: 'Activity Insight',
+                                  publication: p2)}
+
+      it 'groups the publications' do
+        described_class.group_duplicates_of(p2)
+        group = p2.reload.duplicate_group
+
+        expect(group).not_to be_nil
+        expect(p1.reload.duplicate_group).to eq group
+      end
+    end
+
+    context 'given a publication that has the same DOI but different doi casing, title, and year and the other has only an Activity Insight import' do
+      let!(:p1) { create(:publication,
+                         title: 'A match with only one import from Activity Insight',
+                         published_on: Date.new(1989, 1, 1),
+                         doi: 'https://doi.org/10.000/some-doi-457472486') }
+
+      let!(:p2) { create(:publication,
+                         title: 'A Different Title',
+                         published_on: Date.new(1986, 1, 1),
+                         doi: 'https://doi.org/10.000/some-DOI-457472486') }
 
       let!(:p2_import_1) { create(:publication_import,
                                   source: 'Activity Insight',


### PR DESCRIPTION
Fixes #936 

Grouping appears to be the only place that had case sensitive doi matching. The auto merge matching and importers already  handle casing.