### PR TITLE
exclude extension publication pub types from OAB & unpaywall 

### DIFF
--- a/app/importers/oab_client.rb
+++ b/app/importers/oab_client.rb
@@ -8,7 +8,7 @@ class OABClient
                  "https://api.openaccessbutton.org/find?title=#{CGI.escape(cleaned_title(publication))}"
                end
 
-    json = JSON.parse(HttpService.get(find_url))
+    json = publication.publication_type == 'Extension Publication' ? {} : JSON.parse(HttpService.get(find_url))
     OABResponse.new(json)
   end
 

--- a/app/importers/unpaywall_client.rb
+++ b/app/importers/unpaywall_client.rb
@@ -6,9 +6,11 @@ class UnpaywallClient
       doi_url_path = Addressable::URI.encode(publication.doi_url_path)
       find_url = "https://api.unpaywall.org/v2/#{doi_url_path}?email=openaccess@psu.edu"
       json = JSON.parse(HttpService.get(find_url))
-    else
+    elsif publication.publication_type != 'Extension Publication'
       find_url = "https://api.unpaywall.org/v2/search/?query=#{CGI.escape(publication.title)}&email=openaccess@psu.edu"
       json = JSON.parse(HttpService.get(find_url))['results'].blank? ? '' : JSON.parse(HttpService.get(find_url))['results'].first['response']
+    else
+      json = {}
     end
 
     UnpaywallResponse.new(json)

--- a/lib/tasks/imports.rake
+++ b/lib/tasks/imports.rake
@@ -136,33 +136,6 @@ namespace :import do
     PurePublicationImporter.new.call
     PurePublicationTagImporter.new.call
   end
-
-  desc 'Import all data'
-  task all: :environment do
-    PureOrganizationsImporter.new.call
-    ActivityInsightImporter.new.call
-    PureUserImporter.new.call
-    PurePublishersImporter.new.call
-    PureJournalsImporter.new.call
-    PurePublicationImporter.new.call
-    PurePublicationTagImporter.new.call
-
-    ETDCSVImporter.new(
-      filename: filename_for(:etds)
-    ).call
-
-    CommitteeImporter.new(
-      filename: filename_for(:committees)
-    ).call
-
-    NSFGrantImporter.new(
-      dirname: dirname_for(:nsf_grants)
-    ).call
-
-    OpenAccessButtonPublicationImporter.new.import_all
-    UnpaywallPublicationImporter.new.import_all
-    ScholarsphereImporter.new.call
-  end
 end
 
 def filename_for(key)

--- a/spec/component/importers/oab_client_spec.rb
+++ b/spec/component/importers/oab_client_spec.rb
@@ -66,6 +66,21 @@ describe OABClient do
         end
       end
     end
+
+    context 'when the publication type is Extension Publication' do
+      before { allow(OABResponse).to receive(:new).with({}).and_return(empty_response) }
+
+      let(:pub) { create(:publication,
+                         doi: nil,
+                         title: title,
+                         publication_type: 'Extension Publication') }
+
+      let(:empty_response) { instance_double OABResponse }
+
+      it 'returns an empty hash' do
+        expect(client.query_open_access_button(pub)).to eq empty_response
+      end
+    end
   end
 
   describe '#query_open_access_button' do

--- a/spec/component/importers/unpaywall_client_spec.rb
+++ b/spec/component/importers/unpaywall_client_spec.rb
@@ -66,6 +66,23 @@ describe UnpaywallClient do
         end
       end
     end
+
+    context 'when the publication type is Extension Publication' do
+      before do
+        allow(UnpaywallResponse).to receive(:new).with({}).and_return(empty_response)
+      end
+
+      let(:pub) { create(:publication,
+                         doi: doi,
+                         title: title,
+                         publication_type: 'Extension Publication') }
+      let(:doi) { nil }
+      let(:empty_response) { instance_double UnpaywallResponse }
+
+      it 'returns an empty hash' do
+        expect(client.query_unpaywall(pub)).to eq empty_response
+      end
+    end
   end
 
   describe '#query_unpaywall' do

--- a/spec/component/importers/unpaywall_publication_importer_spec.rb
+++ b/spec/component/importers/unpaywall_publication_importer_spec.rb
@@ -510,32 +510,32 @@ describe UnpaywallPublicationImporter, :vcr do
 
         context 'when the Unpaywall response has a DOI' do
           it 'creates a new open access location for the publication' do
-            expect { importer.import_before }.to change { pub.open_access_locations.count }.by 2
+            expect { importer.import_new }.to change { pub.open_access_locations.count }.by 2
           end
 
           it 'assigns the metadata from Unpaywall to the new open access location' do
-            importer.import_before
+            importer.import_new
             oal = pub.open_access_locations.find_by(source: Source::UNPAYWALL)
             expect(oal.url).to eq 'http://arxiv.org/pdf/gr-qc/9801069'
           end
 
           it 'updates Unpaywall check timestamp on the publication' do
-            importer.import_before
+            importer.import_new
             expect(pub.reload.unpaywall_last_checked_at).to be_within(1.minute).of(Time.zone.now)
           end
 
           it 'updates the open access status on the publication' do
-            importer.import_before
+            importer.import_new
             expect(pub.reload.open_access_status).to eq 'green'
           end
 
           it 'assigns the DOI from Unpaywall to the publication' do
-            importer.import_before
+            importer.import_new
             expect(pub.reload.doi).to eq 'https://doi.org/10.1103/physrevlett.80.3915'
           end
 
           it 'updates the DOI verification on the publication' do
-            importer.import_before
+            importer.import_new
             expect(pub.reload.doi_verified).to be true
           end
         end
@@ -543,17 +543,17 @@ describe UnpaywallPublicationImporter, :vcr do
         context 'when the Unpaywall response does not have a doi' do
           # removed DOI from cassettes
           it 'does not update the DOI on the publication' do
-            importer.import_before
+            importer.import_new
             expect(pub.reload.doi).to be_nil
           end
 
           it 'does not update the DOI verification status on the publication' do
-            importer.import_before
+            importer.import_new
             expect(pub.reload.doi_verified).to be_nil
           end
 
           it 'updates Unpaywall check timestamp on the publication' do
-            importer.import_before
+            importer.import_new
             expect(pub.reload.unpaywall_last_checked_at).to be_within(1.minute).of(Time.zone.now)
           end
         end
@@ -563,26 +563,26 @@ describe UnpaywallPublicationImporter, :vcr do
         let!(:pub) { create(:publication, doi: nil, open_access_status: nil, title: 'Economic Development') }
 
         it 'does not create any open access locations for the publication' do
-          expect { importer.import_before }.not_to change(OpenAccessLocation, :count)
+          expect { importer.import_new }.not_to change(OpenAccessLocation, :count)
         end
 
         it "updates the publication's Unpaywall check timestamp" do
-          importer.import_before
+          importer.import_new
           expect(pub.reload.unpaywall_last_checked_at).to be_within(1.minute).of(Time.zone.now)
         end
 
         it 'updates the open access status on the publication to unknown' do
-          importer.import_before
+          importer.import_new
           expect(pub.reload.open_access_status).to eq 'unknown'
         end
 
         it 'does not update the DOI on the publication' do
-          importer.import_before
+          importer.import_new
           expect(pub.reload.doi).to be_nil
         end
 
         it 'does not update the DOI verification on the publication' do
-          importer.import_before
+          importer.import_new
           expect(pub.reload.doi_verified).not_to be true
         end
       end
@@ -593,32 +593,32 @@ describe UnpaywallPublicationImporter, :vcr do
         let!(:pub) { create(:publication, doi: '', open_access_status: nil, title: 'Stable characteristic evolution of generic three-dimensional single-black-hole spacetimes') }
 
         it 'creates a new open access location for the publication' do
-          expect { importer.import_before }.to change { pub.open_access_locations.count }.by 2
+          expect { importer.import_new }.to change { pub.open_access_locations.count }.by 2
         end
 
         it 'assigns the metadata from Unpaywall to the new open access location' do
-          importer.import_before
+          importer.import_new
           oal = pub.open_access_locations.find_by(source: Source::UNPAYWALL)
           expect(oal.url).to eq 'http://arxiv.org/pdf/gr-qc/9801069'
         end
 
         it 'updates Unpaywall check timestamp on the publication' do
-          importer.import_before
+          importer.import_new
           expect(pub.reload.unpaywall_last_checked_at).to be_within(1.minute).of(Time.zone.now)
         end
 
         it 'updates the open access status on the publication' do
-          importer.import_before
+          importer.import_new
           expect(pub.reload.open_access_status).to eq 'green'
         end
 
         it 'assigns the DOI from Unpaywall to the publication' do
-          importer.import_before
+          importer.import_new
           expect(pub.reload.doi).to eq 'https://doi.org/10.1103/physrevlett.80.3915'
         end
 
         it 'updates the DOI verification on the publication' do
-          importer.import_before
+          importer.import_new
           expect(pub.reload.doi_verified).to be true
         end
       end
@@ -627,26 +627,56 @@ describe UnpaywallPublicationImporter, :vcr do
         let!(:pub) { create(:publication, doi: '', open_access_status: nil, title: 'Economic Development') }
 
         it 'does not create any open access locations for the publication' do
-          expect { importer.import_before }.not_to change(OpenAccessLocation, :count)
+          expect { importer.import_new }.not_to change(OpenAccessLocation, :count)
         end
 
         it "updates the publication's Unpaywall check timestamp" do
-          importer.import_before
+          importer.import_new
           expect(pub.reload.unpaywall_last_checked_at).to be_within(1.minute).of(Time.zone.now)
         end
 
         it 'updates the open access status on the publication to unknown' do
-          importer.import_before
+          importer.import_new
           expect(pub.reload.open_access_status).to eq 'unknown'
         end
 
         it 'does not update the DOI from Unpaywall to the publication' do
-          importer.import_before
+          importer.import_new
           expect(pub.reload.doi).to eq ''
         end
 
         it 'does not update the DOI verification on the publication' do
-          importer.import_before
+          importer.import_new
+          expect(pub.reload.doi_verified).not_to be true
+        end
+      end
+
+      context 'when the publication type is Extension Publication' do
+        let!(:pub) { create(:publication, doi: '', open_access_status: nil,
+                                          publication_type: 'Extension Publication',
+                                          title: 'Stable characteristic evolution of generic three-dimensional single-black-hole spacetimes') }
+
+        it 'does not create any open access locations for the publication' do
+          expect { importer.import_new }.not_to change(OpenAccessLocation, :count)
+        end
+
+        it "updates the publication's Unpaywall check timestamp" do
+          importer.import_new
+          expect(pub.reload.unpaywall_last_checked_at).to be_within(1.minute).of(Time.zone.now)
+        end
+
+        it 'updates the open access status on the publication to unknown' do
+          importer.import_new
+          expect(pub.reload.open_access_status).to eq 'unknown'
+        end
+
+        it 'does not update the DOI from Unpaywall to the publication' do
+          importer.import_new
+          expect(pub.reload.doi).to eq ''
+        end
+
+        it 'does not update the DOI verification on the publication' do
+          importer.import_new
           expect(pub.reload.doi_verified).not_to be true
         end
       end


### PR DESCRIPTION
Fixes #962 

I was debating about where to put the logic for this. Code wise the most efficient approach is putting it in the unpaywall/OAB clients so we're never actually making a call out on extension publications & just returning an empty hash as the response (similar to what we would get if the publication couldn't be found) as opposed to adding logic to everywhere we make unpaywall/OAB calls. However, in many of those places we're processing that response  (like `Publication#update_from_unpaywall`) & it seems like it would be functionally more efficient to put `return if pub type == extension publication` at the beginning of the method and skip all of that processing. I went with putting it in the client to keep it DRY, but I'm open to thoughts/suggestions.

This also has some code clean up. The rake task is no longer used & calls an `UnpaywallPublicationImporter` method that no longer exists. The spec was using a different method than the describe block is testing.