### PR TITLE
Create an endpoint for ScholarSphere webhooks to delete open access locations in RMD

### DIFF
--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class WebhooksController < ApplicationController
+  skip_before_action :verify_authenticity_token
+  before_action :authenticate_request
+
+  def scholarsphere_events
+    if params[:publication_url].present?
+      locations = OpenAccessLocation.where(source: Source::SCHOLARSPHERE, url: params[:publication_url])
+      return head(:not_found) if locations.none?
+
+      locations.destroy_all
+      head :no_content
+    else
+      head :bad_request
+    end
+  end
+
+  private
+
+    def authenticate_request
+      raise 'ScholarSphere webhook secret not configured.' if Settings.scholarsphere.webhook_secret.blank?
+
+      return head(:unauthorized) unless request.headers['X-API-KEY'] == Settings.scholarsphere.webhook_secret
+    end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -116,4 +116,6 @@ Rails.application.routes.draw do
 
   put 'user_performances/sort' => 'user_performances#sort'
   put 'user_performances/:id' => 'user_performances#update', as: :user_performance
+
+  post 'webhooks/scholarsphere_events' => 'webhooks#scholarsphere_events', as: :scholarsphere_events_webhook
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -44,5 +44,6 @@ pure:
 scholarsphere:
   endpoint: 
   client_key: 
+  webhook_secret: 
 
 

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -9,6 +9,7 @@ activity_insight:
 scholarsphere:
   endpoint: "https://scholarsphere.test/api/"
   client_key:  "secret_key"
+  webhook_secret: "webhooksecret123"
 
 azure_ad_oauth:
   client_secret: test-azure-oauth-client-secret

--- a/spec/requests/webhooks_spec.rb
+++ b/spec/requests/webhooks_spec.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+require 'requests/requests_spec_helper'
+
+describe WebhooksController do
+  let!(:ss_oal) {
+    create(
+      :open_access_location,
+      source: Source::SCHOLARSPHERE,
+      url: 'https://scholarsphere.psu.edu/test'
+    )
+  }
+
+  let!(:ss_oal2) {
+    create(
+      :open_access_location,
+      source: Source::SCHOLARSPHERE,
+      url: 'https://scholarsphere.psu.edu/test'
+    )
+  }
+
+  let!(:ss_oal3) {
+    create(
+      :open_access_location,
+      source: Source::SCHOLARSPHERE,
+      url: 'https://scholarsphere.psu.edu/test2'
+    )
+  }
+
+  let!(:upw_oal) {
+    create(
+      :open_access_location,
+      source: Source::UNPAYWALL,
+      url: 'https://somesite.com/test'
+    )
+  }
+
+  describe 'POST /webhooks/scholarsphere_events' do
+    context 'when not given an API key header' do
+      it 'returns 401' do
+        post scholarsphere_events_webhook_path
+
+        expect(response).to have_http_status :unauthorized
+      end
+    end
+
+    context 'when given an API key header with an incorrect key' do
+      it 'returns 401' do
+        post scholarsphere_events_webhook_path, headers: { 'X-API-KEY' => 'badkey' }
+
+        expect(response).to have_http_status :unauthorized
+      end
+    end
+
+    context 'when given an API key header with the correct key' do
+      context 'when not given a publication_url param' do
+        it 'returns 400' do
+          post scholarsphere_events_webhook_path, headers: { 'X-API-KEY' => 'webhooksecret123' }
+
+          expect(response).to have_http_status :bad_request
+        end
+      end
+
+      context 'when given a blank publication_url param' do
+        it 'returns 400' do
+          post(
+            scholarsphere_events_webhook_path,
+            headers: { 'X-API-KEY' => 'webhooksecret123' },
+            params: { publication_url: '' }
+          )
+
+          expect(response).to have_http_status :bad_request
+        end
+      end
+
+      context 'when given a publication_url param that does not match an existing open access location' do
+        it 'returns 404' do
+          post(
+            scholarsphere_events_webhook_path,
+            headers: { 'X-API-KEY' => 'webhooksecret123' },
+            params: { publication_url: 'unknown-url' }
+          )
+
+          expect(response).to have_http_status :not_found
+        end
+      end
+
+      context 'when given a publication_url param that matches an open access location that did not come from ScholarSphere' do
+        it 'does not delete the open access location' do
+          post(
+            scholarsphere_events_webhook_path,
+            headers: { 'X-API-KEY' => 'webhooksecret123' },
+            params: { publication_url: 'https://somesite.com/test' }
+          )
+
+          expect { upw_oal.reload }.not_to raise_error
+        end
+
+        it 'returns 404' do
+          post(
+            scholarsphere_events_webhook_path,
+            headers: { 'X-API-KEY' => 'webhooksecret123' },
+            params: { publication_url: 'https://somesite.com/test' }
+          )
+
+          expect(response).to have_http_status :not_found
+        end
+      end
+
+      context 'when given a publication_url param that matches open access locations that came from ScholarSphere' do
+        it 'deletes the matching open access locations' do
+          post(
+            scholarsphere_events_webhook_path,
+            headers: { 'X-API-KEY' => 'webhooksecret123' },
+            params: { publication_url: 'https://scholarsphere.psu.edu/test' }
+          )
+
+          expect { ss_oal.reload }.to raise_error ActiveRecord::RecordNotFound
+          expect { ss_oal2.reload }.to raise_error ActiveRecord::RecordNotFound
+        end
+
+        it 'does not delete non-matching open access locations that came from ScholarSphere' do
+          post(
+            scholarsphere_events_webhook_path,
+            headers: { 'X-API-KEY' => 'webhooksecret123' },
+            params: { publication_url: 'https://scholarsphere.psu.edu/test' }
+          )
+
+          expect { ss_oal3.reload }.not_to raise_error
+        end
+
+        it 'returns 204' do
+          post(
+            scholarsphere_events_webhook_path,
+            headers: { 'X-API-KEY' => 'webhooksecret123' },
+            params: { publication_url: 'https://scholarsphere.psu.edu/test' }
+          )
+
+          expect(response).to have_http_status :no_content
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
closes #766 

I think I made this about as simple as I could.