### PR TITLE
updates to permissions metadata

### DIFF
--- a/app/jobs/file_permissions_check_job.rb
+++ b/app/jobs/file_permissions_check_job.rb
@@ -7,7 +7,7 @@ class FilePermissionsCheckJob < ApplicationJob
     file = ActivityInsightOAFile.find(file_id)
     permissions = OABPermissionsService.new(file.doi_url_path, file.version)
 
-    file.license = permissions.licence
+    file.license = (permissions.licence.presence || 'https://rightsstatements.org/page/InC/1.0/')
     file.set_statement = permissions.set_statement
     file.embargo_date = permissions.embargo_end_date
     file.checked_for_set_statement = true

--- a/app/jobs/file_permissions_check_job.rb
+++ b/app/jobs/file_permissions_check_job.rb
@@ -7,11 +7,11 @@ class FilePermissionsCheckJob < ApplicationJob
     file = ActivityInsightOAFile.find(file_id)
     permissions = OABPermissionsService.new(file.doi_url_path, file.version)
 
+    return unless permissions.permissions_found?
+
     file.license = (permissions.licence.presence || 'https://rightsstatements.org/page/InC/1.0/')
-    file.set_statement = permissions.set_statement
-    file.embargo_date = permissions.embargo_end_date
-    file.checked_for_set_statement = true
-    file.checked_for_embargo_date = true
+    permissions.set_statement.present? ? file.set_statement = permissions.set_statement : file.checked_for_set_statement = true
+    permissions.embargo_end_date.present? ? file.embargo_date = permissions.embargo_end_date : file.checked_for_embargo_date = true
     file.save!
   end
 end

--- a/app/services/oab_permissions_service.rb
+++ b/app/services/oab_permissions_service.rb
@@ -38,4 +38,8 @@ class OABPermissionsService < OABPermissionsClient
 
     {}
   end
+
+  def permissions_found?
+    all_permissions.present?
+  end
 end

--- a/lib/tasks/oa_workflow.rake
+++ b/lib/tasks/oa_workflow.rake
@@ -4,3 +4,11 @@ desc 'Move publications through the open access workflow'
 task oa_workflow: :environment do
   OAWorkflowService.new.workflow
 end
+
+desc 'One time update to set all permissions flags'
+task permissions_check_all: :environment do
+  ActivityInsightOAFile.all.each do |file|
+    file.update!(permissions_last_checked_at: Time.current)
+    FilePermissionsCheckJob.perform_later(file.id)
+  end
+end

--- a/spec/component/jobs/file_permissions_check_job_spec.rb
+++ b/spec/component/jobs/file_permissions_check_job_spec.rb
@@ -27,61 +27,83 @@ describe FilePermissionsCheckJob, type: :job do
       )
     }
 
-    context 'when OAB returns a license' do
-      before do
-        allow(HTTParty).to receive(:get).with('https://api.openaccessbutton.org/permissions/10.1016%2FS0962-1849%2805%2980014-9')
-          .and_return(Rails.root.join('spec', 'fixtures', 'oab7.json').read)
+    context 'when some permissions data is returned' do
+      context 'when all fields are present' do
+        before do
+          allow(HTTParty).to receive(:get).with('https://api.openaccessbutton.org/permissions/10.1016%2FS0962-1849%2805%2980014-9')
+            .and_return(Rails.root.join('spec', 'fixtures', 'oab7.json').read)
+        end
+
+        context "when the file's version is acceptedVersion" do
+          let(:version) { 'acceptedVersion' }
+
+          it "updates the file's permissions fields with the correct metadata for the accepted version" do
+            job.perform_now(file.id)
+
+            f = file.reload
+            expect(f.license).to eq 'https://rightsstatements.org/page/InC/1.0/'
+            expect(f.set_statement).to eq(
+              'This version of the article has been accepted for publication, after peer review (when applicable) ' +
+              'and is subject to Springer Nature’s AM terms of use, but is not the Version of Record and does not reflect post-acceptance improvements, or any corrections. The Version of Record is available online at: http://dx.doi.org/10.1038/s41598-023-28289-6'
+            )
+            expect(f.embargo_date).to eq Date.new(2024, 1, 24)
+            expect(f.checked_for_set_statement).to be_nil
+            expect(f.checked_for_embargo_date).to be_nil
+          end
+        end
+
+        context "when the file's version is publishedVersion" do
+          let(:version) { 'publishedVersion' }
+
+          it "updates the file's permissions fields with the correct metadata for the published version" do
+            job.perform_now(file.id)
+
+            f = file.reload
+            expect(f.license).to eq 'https://creativecommons.org/licenses/by/4.0/'
+            expect(f.set_statement).to eq 'This is a published article.'
+            expect(f.embargo_date).to eq Date.new(2022, 1, 24)
+            expect(f.checked_for_set_statement).to be_nil
+            expect(f.checked_for_embargo_date).to be_nil
+          end
+        end
       end
 
-      context "when the file's version is acceptedVersion" do
+      context 'when license, set statement, and embargo are missing' do
         let(:version) { 'acceptedVersion' }
 
-        it "updates the file's permissions fields with the correct metadata for the accepted version" do
+        before do
+          allow(HTTParty).to receive(:get).with('https://api.openaccessbutton.org/permissions/10.1016%2FS0962-1849%2805%2980014-9')
+            .and_return(Rails.root.join('spec', 'fixtures', 'oab10.json').read)
+        end
+
+        it 'sets alternate values for the missing fields' do
           job.perform_now(file.id)
 
           f = file.reload
           expect(f.license).to eq 'https://rightsstatements.org/page/InC/1.0/'
-          expect(f.set_statement).to eq(
-            'This version of the article has been accepted for publication, after peer review (when applicable) ' +
-            'and is subject to Springer Nature’s AM terms of use, but is not the Version of Record and does not reflect post-acceptance improvements, or any corrections. The Version of Record is available online at: http://dx.doi.org/10.1038/s41598-023-28289-6'
-          )
-          expect(f.embargo_date).to eq Date.new(2024, 1, 24)
-          expect(f.checked_for_set_statement).to be true
-          expect(f.checked_for_embargo_date).to be true
-        end
-      end
-
-      context "when the file's version is publishedVersion" do
-        let(:version) { 'publishedVersion' }
-
-        it "updates the file's permissions fields with the correct metadata for the published version" do
-          job.perform_now(file.id)
-
-          f = file.reload
-          expect(f.license).to eq 'https://creativecommons.org/licenses/by/4.0/'
-          expect(f.set_statement).to eq 'This is a published article.'
-          expect(f.embargo_date).to eq Date.new(2022, 1, 24)
+          expect(f.set_statement).to be_nil
+          expect(f.embargo_date).to be_nil
           expect(f.checked_for_set_statement).to be true
           expect(f.checked_for_embargo_date).to be true
         end
       end
     end
 
-    context 'when OAB does not return a license' do
+    context 'when OAB does not return any permissions data' do
       let(:version) { 'acceptedVersion' }
 
       before do
         allow(HTTParty).to receive(:get).with('https://api.openaccessbutton.org/permissions/10.1016%2FS0962-1849%2805%2980014-9')
-          .and_return(Rails.root.join('spec', 'fixtures', 'oab10.json').read)
+          .and_return(Rails.root.join('spec', 'fixtures', 'oab5.json').read)
       end
 
-      it "updates the file's license field with All rights reserved" do
+      it "doesn't update any fields" do
         job.perform_now(file.id)
 
         f = file.reload
-        expect(f.license).to eq 'https://rightsstatements.org/page/InC/1.0/'
-        expect(f.checked_for_set_statement).to be true
-        expect(f.checked_for_embargo_date).to be true
+        expect(f.license).to be_nil
+        expect(f.checked_for_set_statement).to be_nil
+        expect(f.checked_for_embargo_date).to be_nil
       end
     end
   end

--- a/spec/component/jobs/file_permissions_check_job_spec.rb
+++ b/spec/component/jobs/file_permissions_check_job_spec.rb
@@ -27,39 +27,59 @@ describe FilePermissionsCheckJob, type: :job do
       )
     }
 
-    before do
-      allow(HTTParty).to receive(:get).with('https://api.openaccessbutton.org/permissions/10.1016%2FS0962-1849%2805%2980014-9')
-        .and_return(Rails.root.join('spec', 'fixtures', 'oab7.json').read)
+    context 'when OAB returns a license' do
+      before do
+        allow(HTTParty).to receive(:get).with('https://api.openaccessbutton.org/permissions/10.1016%2FS0962-1849%2805%2980014-9')
+          .and_return(Rails.root.join('spec', 'fixtures', 'oab7.json').read)
+      end
+
+      context "when the file's version is acceptedVersion" do
+        let(:version) { 'acceptedVersion' }
+
+        it "updates the file's permissions fields with the correct metadata for the accepted version" do
+          job.perform_now(file.id)
+
+          f = file.reload
+          expect(f.license).to eq 'https://rightsstatements.org/page/InC/1.0/'
+          expect(f.set_statement).to eq(
+            'This version of the article has been accepted for publication, after peer review (when applicable) ' +
+            'and is subject to Springer Nature’s AM terms of use, but is not the Version of Record and does not reflect post-acceptance improvements, or any corrections. The Version of Record is available online at: http://dx.doi.org/10.1038/s41598-023-28289-6'
+          )
+          expect(f.embargo_date).to eq Date.new(2024, 1, 24)
+          expect(f.checked_for_set_statement).to be true
+          expect(f.checked_for_embargo_date).to be true
+        end
+      end
+
+      context "when the file's version is publishedVersion" do
+        let(:version) { 'publishedVersion' }
+
+        it "updates the file's permissions fields with the correct metadata for the published version" do
+          job.perform_now(file.id)
+
+          f = file.reload
+          expect(f.license).to eq 'https://creativecommons.org/licenses/by/4.0/'
+          expect(f.set_statement).to eq 'This is a published article.'
+          expect(f.embargo_date).to eq Date.new(2022, 1, 24)
+          expect(f.checked_for_set_statement).to be true
+          expect(f.checked_for_embargo_date).to be true
+        end
+      end
     end
 
-    context "when the file's version is acceptedVersion" do
+    context 'when OAB does not return a license' do
       let(:version) { 'acceptedVersion' }
 
-      it "updates the file's permissions fields with the correct metadata for the accepted version" do
+      before do
+        allow(HTTParty).to receive(:get).with('https://api.openaccessbutton.org/permissions/10.1016%2FS0962-1849%2805%2980014-9')
+          .and_return(Rails.root.join('spec', 'fixtures', 'oab10.json').read)
+      end
+
+      it "updates the file's license field with All rights reserved" do
         job.perform_now(file.id)
 
         f = file.reload
         expect(f.license).to eq 'https://rightsstatements.org/page/InC/1.0/'
-        expect(f.set_statement).to eq(
-          'This version of the article has been accepted for publication, after peer review (when applicable) ' +
-          'and is subject to Springer Nature’s AM terms of use, but is not the Version of Record and does not reflect post-acceptance improvements, or any corrections. The Version of Record is available online at: http://dx.doi.org/10.1038/s41598-023-28289-6'
-        )
-        expect(f.embargo_date).to eq Date.new(2024, 1, 24)
-        expect(f.checked_for_set_statement).to be true
-        expect(f.checked_for_embargo_date).to be true
-      end
-    end
-
-    context "when the file's version is publishedVersion" do
-      let(:version) { 'publishedVersion' }
-
-      it "updates the file's permissions fields with the correct metadata for the published version" do
-        job.perform_now(file.id)
-
-        f = file.reload
-        expect(f.license).to eq 'https://creativecommons.org/licenses/by/4.0/'
-        expect(f.set_statement).to eq 'This is a published article.'
-        expect(f.embargo_date).to eq Date.new(2022, 1, 24)
         expect(f.checked_for_set_statement).to be true
         expect(f.checked_for_embargo_date).to be true
       end

--- a/spec/component/services/oab_permissions_service_spec.rb
+++ b/spec/component/services/oab_permissions_service_spec.rb
@@ -221,6 +221,28 @@ describe OABPermissionsService do
         end
       end
     end
+
+    describe '#permissions_found?' do
+      context 'when some permissions are found' do
+        before do
+          allow(HTTParty).to receive(:get).and_return(Rails.root.join('spec', 'fixtures', 'oab7.json').read)
+        end
+
+        it 'returns true' do
+          expect(service.permissions_found?).to be true
+        end
+      end
+
+      context 'when no permissions data is returned' do
+        before do
+          allow(HTTParty).to receive(:get).and_return(Rails.root.join('spec', 'fixtures', 'oab5.json').read)
+        end
+
+        it 'returns false' do
+          expect(service.permissions_found?).to be false
+        end
+      end
+    end
   end
 
   context 'when version is not valid' do

--- a/spec/fixtures/oab5.json
+++ b/spec/fixtures/oab5.json
@@ -1,4 +1,3 @@
 {
-    "no-data": {
-    }
-  }
+  "all_permissions": []
+}


### PR DESCRIPTION
Fixes #1052 

Set license to 'All rights reserved' when OAButton returns permissions, but fails to return a license. Applies this logic to `checked_for_set_statement` and `checked_for_embargo_date` flags as well - flags are currently set to true whenever OAB is checked, but they should only be set when OAB returns permissions without set statement/embargo date.

Also has one time rake task that will run all AI OA files through new permissions check (flags when no set statement or embargo found & sets license)