### PR TITLE
allow download link when in ai oa workflow

### DIFF
--- a/app/controllers/open_access_publications_controller.rb
+++ b/app/controllers/open_access_publications_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class OpenAccessPublicationsController < OpenAccessWorkflowController
-  skip_before_action :redirect_if_inaccessible, only: [:edit]
+  skip_before_action :redirect_if_inaccessible, only: [:edit, :activity_insight_file_download]
 
   def edit
     if publication.no_open_access_information?


### PR DESCRIPTION
Changes in #1070 inadvertently block the download link, this allows file download when the file is in the AI OA workflow and otherwise considered inaccessible