### PR TITLE
944 remove deleted publications

### DIFF
--- a/app/importers/pure_importer.rb
+++ b/app/importers/pure_importer.rb
@@ -1,21 +1,9 @@
 # frozen_string_literal: true
 
-class PureImporter
+class PureImporter < PureAPIClient
   class ServiceNotFound < RuntimeError; end
 
   private
-
-    def api_version
-      '524'
-    end
-
-    def base_url
-      "https://pure.psu.edu/ws/api/#{api_version}"
-    end
-
-    def pure_api_key
-      Settings.pure.api_key
-    end
 
     def total_records
       response = get_records(type: record_type, page_size: 1, offset: 0)

--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -8,6 +8,10 @@ class Import < ApplicationRecord
   validates :source, inclusion: { in: SOURCES }
 
   def self.latest_completed_from_pure
-    Import.where(source: 'Pure').where.not(completed_at: nil).order(:completed_at).last
+    where(source: 'Pure').where.not(completed_at: nil).order(:completed_at).last
+  end
+
+  def self.latest_completed_from_ai
+    where(source: 'Activity Insight').where.not(completed_at: nil).order(:completed_at).last
   end
 end

--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -6,4 +6,8 @@ class Import < ApplicationRecord
   has_many :source_publications
 
   validates :source, inclusion: { in: SOURCES }
+
+  def self.latest_completed_from_pure
+    Import.where(source: 'Pure').where.not(completed_at: nil).order(:completed_at).last
+  end
 end

--- a/app/models/source_publication.rb
+++ b/app/models/source_publication.rb
@@ -1,5 +1,22 @@
 # frozen_string_literal: true
 
 class SourcePublication < ApplicationRecord
+  class NoCompletedPureImports < RuntimeError; end
+
   belongs_to :import
+
+  def self.find_in_latest_pure_list(publication)
+    latest_completed_pure_import = Import.latest_completed_from_pure
+    raise NoCompletedPureImports if latest_completed_pure_import.nil?
+    if publication.pure_imports.none?
+      raise ArgumentError.new('The given publication has not been imported from Pure.')
+    end
+
+    publication.pure_imports.each do |i|
+      found_pub = find_by(import: latest_completed_pure_import, source_identifier: i.source_identifier)
+      return found_pub if found_pub
+    end
+
+    nil
+  end
 end

--- a/app/models/source_publication.rb
+++ b/app/models/source_publication.rb
@@ -2,18 +2,34 @@
 
 class SourcePublication < ApplicationRecord
   class NoCompletedPureImports < RuntimeError; end
+  class NoCompletedAIImports < RuntimeError; end
 
   belongs_to :import
 
   def self.find_in_latest_pure_list(publication)
     latest_completed_pure_import = Import.latest_completed_from_pure
     raise NoCompletedPureImports if latest_completed_pure_import.nil?
-    if publication.pure_imports.none?
-      raise ArgumentError.new('The given publication has not been imported from Pure.')
-    end
 
     publication.pure_imports.each do |i|
-      found_pub = find_by(import: latest_completed_pure_import, source_identifier: i.source_identifier)
+      found_pub = find_by(
+        import: latest_completed_pure_import,
+        source_identifier: i.source_identifier
+      )
+      return found_pub if found_pub
+    end
+
+    nil
+  end
+
+  def self.find_in_latest_ai_list(publication)
+    latest_completed_ai_import = Import.latest_completed_from_ai
+    raise NoCompletedAIImports if latest_completed_ai_import.nil?
+
+    publication.ai_imports.each do |i|
+      found_pub = where(
+        import: latest_completed_ai_import,
+        source_identifier: i.source_identifier
+      ).where(%{status = 'Published' OR status = 'In Press'}).first
       return found_pub if found_pub
     end
 

--- a/app/services/publication_cleanup_service.rb
+++ b/app/services/publication_cleanup_service.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module PublicationCleanupService
+  def self.clean_up_pure_publications(dry_run: true)
+    Publication.with_only_pure_imports.find_each do |pub|
+      if !SourcePublication.find_in_latest_pure_list(pub) && PurePersonFinder.new.detect_publication_author(pub)
+        if dry_run
+          puts "Publication #{pub.id} will be deleted"
+        else
+          puts "Deleting publication #{pub.id}"
+          pub.destroy!
+        end
+      end
+    end
+  end
+end

--- a/app/services/pure_api_client.rb
+++ b/app/services/pure_api_client.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class PureAPIClient
+  private
+
+    def api_version
+      '524'
+    end
+
+    def base_url
+      "https://pure.psu.edu/ws/api/#{api_version}"
+    end
+
+    def pure_api_key
+      Settings.pure.api_key
+    end
+end

--- a/app/services/pure_person_finder.rb
+++ b/app/services/pure_person_finder.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class PurePersonFinder < PureAPIClient
+  def detect_publication_author(pub)
+    pub.users.each do |u|
+      return u if detect_person(u)
+    end
+    nil
+  end
+
+  private
+
+    def detect_person(user)
+      response = HTTParty.get(
+        "#{base_url}/persons/#{user.pure_uuid}",
+        headers: { 'api-key' => pure_api_key.to_s }
+      )
+      response.code == 200
+    end
+end

--- a/spec/component/models/import_spec.rb
+++ b/spec/component/models/import_spec.rb
@@ -62,4 +62,43 @@ describe Import, type: :model do
       end
     end
   end
+
+  describe '.latest_completed_from_ai' do
+    context 'when there are no import records' do
+      it 'returns nil' do
+        expect(described_class.latest_completed_from_ai).to be_nil
+      end
+    end
+
+    context 'when there is only an incomplete import from Activity Insight' do
+      before { create(:import, source: 'Activity Insight', completed_at: nil) }
+
+      it 'returns nil' do
+        expect(described_class.latest_completed_from_ai).to be_nil
+      end
+    end
+
+    context 'when there is only a completed import from Pure' do
+      before { create(:import, source: 'Pure', completed_at: Time.current) }
+
+      it 'returns nil' do
+        expect(described_class.latest_completed_from_ai).to be_nil
+      end
+    end
+
+    context 'when there are multiple import records' do
+      let!(:import) { create(:import, source: 'Activity Insight', completed_at: 1.week.ago) }
+
+      before do
+        create(:import, source: 'Pure', completed_at: 1.day.ago)
+        create(:import, source: 'Activity Insight', completed_at: nil)
+        create(:import, source: 'Activity Insight', completed_at: 1.year.ago)
+        create(:import, source: 'Activity Insight', completed_at: 1.month.ago)
+      end
+
+      it 'returns the most recently completed import from Activity Insight' do
+        expect(described_class.latest_completed_from_ai).to eq import
+      end
+    end
+  end
 end

--- a/spec/component/models/import_spec.rb
+++ b/spec/component/models/import_spec.rb
@@ -23,4 +23,43 @@ describe Import, type: :model do
   describe 'validations' do
     it { is_expected.to validate_inclusion_of(:source).in_array(['Pure', 'Activity Insight']) }
   end
+
+  describe '.latest_completed_from_pure' do
+    context 'when there are no import records' do
+      it 'returns nil' do
+        expect(described_class.latest_completed_from_pure).to be_nil
+      end
+    end
+
+    context 'when there is only an incomplete import from Pure' do
+      before { create(:import, source: 'Pure', completed_at: nil) }
+
+      it 'returns nil' do
+        expect(described_class.latest_completed_from_pure).to be_nil
+      end
+    end
+
+    context 'when there is only a completed import from Activity Insight' do
+      before { create(:import, source: 'Activity Insight', completed_at: Time.current) }
+
+      it 'returns nil' do
+        expect(described_class.latest_completed_from_pure).to be_nil
+      end
+    end
+
+    context 'when there are multiple import records' do
+      let!(:import) { create(:import, source: 'Pure', completed_at: 1.week.ago) }
+
+      before do
+        create(:import, source: 'Activity Insight', completed_at: 1.day.ago)
+        create(:import, source: 'Pure', completed_at: nil)
+        create(:import, source: 'Pure', completed_at: 1.year.ago)
+        create(:import, source: 'Pure', completed_at: 1.month.ago)
+      end
+
+      it 'returns the most recently completed import from Pure' do
+        expect(described_class.latest_completed_from_pure).to eq import
+      end
+    end
+  end
 end

--- a/spec/component/models/publication_spec.rb
+++ b/spec/component/models/publication_spec.rb
@@ -1414,7 +1414,7 @@ describe Publication, type: :model do
     end
 
     it 'returns publications that have a Pure or Activity Insight import, no imports from other sources, no files, no waivers, and no user or ScholarSphere open access locations' do
-      expect(described_class.eligible_for_cleanup_check).to match_array [pub2, pub3, pub4, pub9, pub14, pub15]
+      expect(described_class.eligible_for_cleanup_check).to contain_exactly(pub2, pub3, pub4, pub9, pub14, pub15)
     end
   end
 
@@ -3971,7 +3971,7 @@ describe Publication, type: :model do
       let(:pub) { create(:publication, imports: [pure_import]) }
 
       it 'returns an array containing the import' do
-        expect(pub.pure_imports).to match_array [pure_import]
+        expect(pub.pure_imports).to contain_exactly(pure_import)
       end
     end
 
@@ -4000,7 +4000,7 @@ describe Publication, type: :model do
       let(:pub) { create(:publication, imports: [ai_import]) }
 
       it 'returns an array containing the import' do
-        expect(pub.ai_imports).to match_array [ai_import]
+        expect(pub.ai_imports).to contain_exactly(ai_import)
       end
     end
 

--- a/spec/component/models/publication_spec.rb
+++ b/spec/component/models/publication_spec.rb
@@ -1341,24 +1341,80 @@ describe Publication, type: :model do
     end
   end
 
-  describe '.with_only_pure_imports' do
+  describe '.eligible_for_cleanup_check' do
     let!(:pub1) { create(:publication) }
     let!(:pub2) { create(:publication) }
     let!(:pub3) { create(:publication) }
     let!(:pub4) { create(:publication) }
     let!(:pub5) { create(:publication) }
+    let!(:pub6) { create(:publication) }
+    let!(:pub7) { create(:publication) }
+    let!(:pub8) { create(:publication) }
+    let!(:pub9) { create(:publication) }
+    let!(:pub10) { create(:publication) }
+    let!(:pub11) { create(:publication) }
+    let!(:pub12) { create(:publication) }
+    let!(:pub13) { create(:publication) }
+    let!(:pub14) { create(:publication) }
+    let!(:pub15) { create(:publication) }
+    let!(:pub16) { create(:publication) }
+    let!(:pub17) { create(:publication) }
 
     before do
       create(:publication_import, publication: pub2, source: 'Activity Insight')
+
       create(:publication_import, publication: pub3, source: 'Pure')
+
+      create(:publication_import, publication: pub4, source: 'Activity Insight')
       create(:publication_import, publication: pub4, source: 'Pure')
-      create(:publication_import, publication: pub4, source: 'Pure')
+
       create(:publication_import, publication: pub5, source: 'Activity Insight')
-      create(:publication_import, publication: pub5, source: 'Pure')
+      create(:publication_import, publication: pub5, source: 'Web of Science')
+
+      create(:publication_import, publication: pub6, source: 'Pure')
+      create(:publication_import, publication: pub6, source: 'Web of Science')
+
+      create(:publication_import, publication: pub7, source: 'Web of Science')
+
+      create(:publication_import, publication: pub8, source: 'Activity Insight')
+      create(:publication_import, publication: pub8, source: 'Pure')
+      create(:publication_import, publication: pub8, source: 'Web of Science')
+
+      create(:publication_import, publication: pub9, source: 'Activity Insight')
+      create(:publication_import, publication: pub9, source: 'Activity Insight')
+      create(:publication_import, publication: pub9, source: 'Pure')
+
+      create(:publication_import, publication: pub10, source: 'Activity Insight')
+      create(:activity_insight_oa_file, publication: pub10)
+
+      create(:publication_import, publication: pub11, source: 'Activity Insight')
+      create(:open_access_location, publication: pub11, source: 'user')
+
+      create(:publication_import, publication: pub12, source: 'Activity Insight')
+      create(:open_access_location, publication: pub12, source: 'scholarsphere')
+
+      create(:publication_import, publication: pub13, source: 'Activity Insight')
+      pub13_authorship = create(:authorship, publication: pub13)
+      create(:internal_publication_waiver, authorship: pub13_authorship)
+
+      create(:publication_import, publication: pub14, source: 'Activity Insight')
+      create(:authorship, publication: pub14)
+
+      create(:publication_import, publication: pub15, source: 'Activity Insight')
+      create(:open_access_location, publication: pub15, source: 'unpaywall')
+
+      create(:publication_import, publication: pub16, source: 'Activity Insight')
+      create(:open_access_location, publication: pub16, source: 'unpaywall')
+      create(:open_access_location, publication: pub16, source: 'scholarsphere')
+
+      create(:publication_import, publication: pub17, source: 'Activity Insight')
+      pub17_authorship = create(:authorship, publication: pub17)
+      create(:authorship, publication: pub17)
+      create(:internal_publication_waiver, authorship: pub17_authorship)
     end
 
-    it 'returns publications that have one or more imports from Pure and no imports from other sources' do
-      expect(described_class.with_only_pure_imports).to match_array [pub3, pub4]
+    it 'returns publications that have a Pure or Activity Insight import, no imports from other sources, no files, no waivers, and no user or ScholarSphere open access locations' do
+      expect(described_class.eligible_for_cleanup_check).to match_array [pub2, pub3, pub4, pub9, pub14, pub15]
     end
   end
 
@@ -3932,6 +3988,35 @@ describe Publication, type: :model do
 
       it 'returns an empty array' do
         expect(pub.pure_imports).to eq []
+      end
+    end
+  end
+
+  describe '#ai_imports' do
+    let(:pure_import) { build(:publication_import, source: 'Pure') }
+    let(:ai_import) { build(:publication_import, source: 'Activity Insight') }
+
+    context 'when the publication has an import from Activity Insight' do
+      let(:pub) { create(:publication, imports: [ai_import]) }
+
+      it 'returns an array containing the import' do
+        expect(pub.ai_imports).to match_array [ai_import]
+      end
+    end
+
+    context 'when the publication has an import from another source' do
+      let(:pub) { create(:publication, imports: [pure_import]) }
+
+      it 'returns an empty array' do
+        expect(pub.ai_imports).to eq []
+      end
+    end
+
+    context 'when the publication does not have any imports' do
+      let(:pub) { create(:publication) }
+
+      it 'returns an empty array' do
+        expect(pub.ai_imports).to eq []
       end
     end
   end

--- a/spec/component/models/source_publication_spec.rb
+++ b/spec/component/models/source_publication_spec.rb
@@ -22,4 +22,56 @@ describe SourcePublication, type: :model do
   describe 'associations' do
     it { is_expected.to belong_to(:import) }
   end
+
+  describe '.find_in_latest_pure_list' do
+    let!(:pub) { instance_double(Publication, pure_imports: pure_pub_imports) }
+    let(:latest_pure_import) { nil }
+    let(:pure_pub_imports) { [] }
+
+    before { allow(Import).to receive(:latest_completed_from_pure).and_return latest_pure_import }
+
+    context 'when there are no completed Pure imports' do
+      it 'raises an error' do
+        expect { described_class.find_in_latest_pure_list(pub) }.to raise_error SourcePublication::NoCompletedPureImports
+      end
+    end
+
+    context 'when there are complete records of Pure imports' do
+      let!(:latest_pure_import) { create(:import) }
+
+      context 'when the given publication was not imported from Pure' do
+        it 'raises an error' do
+          expect { described_class.find_in_latest_pure_list(pub) }.to raise_error ArgumentError
+        end
+      end
+
+      context 'when the given publication was imported from Pure' do
+        let(:pure_pub_imports) { [ppi] }
+        let(:ppi) { create(:publication_import, source_identifier: 'abc123') }
+
+        context 'when the given publication has a publication import record that is still present in Pure' do
+          let!(:sp) { create(:source_publication, import: latest_pure_import, source_identifier: 'abc123') }
+
+          it 'returns the matching source publication record' do
+            expect(described_class.find_in_latest_pure_list(pub)).to eq sp
+          end
+
+          context 'when the given publication has another publication import record that is not still present in Pure' do
+            let(:pure_pub_imports) { [ppi2, ppi] }
+            let(:ppi2) { create(:publication_import, source_identifier: 'def456') }
+
+            it 'returns the matching source publication record' do
+              expect(described_class.find_in_latest_pure_list(pub)).to eq sp
+            end
+          end
+        end
+
+        context 'when the given publication only has a publication import record that is not still present in Pure' do
+          it 'returns nil' do
+            expect(described_class.find_in_latest_pure_list(pub)).to be_nil
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/component/models/source_publication_spec.rb
+++ b/spec/component/models/source_publication_spec.rb
@@ -40,8 +40,8 @@ describe SourcePublication, type: :model do
       let!(:latest_pure_import) { create(:import) }
 
       context 'when the given publication was not imported from Pure' do
-        it 'raises an error' do
-          expect { described_class.find_in_latest_pure_list(pub) }.to raise_error ArgumentError
+        it 'returns nil' do
+          expect(described_class.find_in_latest_pure_list(pub)).to be_nil
         end
       end
 
@@ -69,6 +69,113 @@ describe SourcePublication, type: :model do
         context 'when the given publication only has a publication import record that is not still present in Pure' do
           it 'returns nil' do
             expect(described_class.find_in_latest_pure_list(pub)).to be_nil
+          end
+        end
+      end
+    end
+  end
+
+  describe '.find_in_latest_ai_list' do
+    let!(:pub) { instance_double(Publication, ai_imports: ai_pub_imports) }
+    let(:latest_ai_import) { nil }
+    let(:ai_pub_imports) { [] }
+
+    before { allow(Import).to receive(:latest_completed_from_ai).and_return latest_ai_import }
+
+    context 'when there are no completed Activity Insight imports' do
+      it 'raises an error' do
+        expect { described_class.find_in_latest_ai_list(pub) }.to raise_error SourcePublication::NoCompletedAIImports
+      end
+    end
+
+    context 'when there are complete records of Activity Insight imports' do
+      let!(:latest_ai_import) { create(:import) }
+
+      context 'when the given publication was not imported from Activity Insight' do
+        it 'returns nil' do
+          expect(described_class.find_in_latest_ai_list(pub)).to be_nil
+        end
+      end
+
+      context 'when the given publication was imported from Activity Insight' do
+        let(:ai_pub_imports) { [aipi] }
+        let(:aipi) { create(:publication_import, source_identifier: 'abc123') }
+
+        context 'when the given publication has a publication import record that is still present in Activity Insight' do
+          let!(:sp) { create(:source_publication, import: latest_ai_import, source_identifier: 'abc123', status: status) }
+
+          context 'when the status in Activity Insight is "Published"' do
+            let(:status) { 'Published' }
+
+            it 'returns the matching source publication record' do
+              expect(described_class.find_in_latest_ai_list(pub)).to eq sp
+            end
+
+            context 'when the given publication has another publication import record that is not still present in Activity Insight' do
+              let(:ai_pub_imports) { [aipi2, aipi] }
+              let(:aipi2) { create(:publication_import, source_identifier: 'def456') }
+
+              it 'returns the matching source publication record' do
+                expect(described_class.find_in_latest_ai_list(pub)).to eq sp
+              end
+            end
+          end
+
+          context 'when the status in Activity Insight is "In Press"' do
+            let(:status) { 'In Press' }
+
+            it 'returns the matching source publication record' do
+              expect(described_class.find_in_latest_ai_list(pub)).to eq sp
+            end
+
+            context 'when the given publication has another publication import record that is not still present in Activity Insight' do
+              let(:ai_pub_imports) { [aipi2, aipi] }
+              let(:aipi2) { create(:publication_import, source_identifier: 'def456') }
+
+              it 'returns the matching source publication record' do
+                expect(described_class.find_in_latest_ai_list(pub)).to eq sp
+              end
+            end
+          end
+
+          context 'when the status in Activity Insight is "Submitted"' do
+            let(:status) { 'Submitted' }
+
+            it 'returns nil' do
+              expect(described_class.find_in_latest_ai_list(pub)).to be_nil
+            end
+
+            context 'when the given publication has another publication import record that is not still present in Activity Insight' do
+              let(:ai_pub_imports) { [aipi2, aipi] }
+              let(:aipi2) { create(:publication_import, source_identifier: 'def456') }
+
+              it 'returns nil' do
+                expect(described_class.find_in_latest_ai_list(pub)).to be_nil
+              end
+            end
+          end
+
+          context 'when the status in Activity Insight is nil' do
+            let(:status) { nil }
+
+            it 'returns nil' do
+              expect(described_class.find_in_latest_ai_list(pub)).to be_nil
+            end
+
+            context 'when the given publication has another publication import record that is not still present in Activity Insight' do
+              let(:ai_pub_imports) { [aipi2, aipi] }
+              let(:aipi2) { create(:publication_import, source_identifier: 'def456') }
+
+              it 'returns nil' do
+                expect(described_class.find_in_latest_ai_list(pub)).to be_nil
+              end
+            end
+          end
+        end
+
+        context 'when the given publication only has a publication import record that is not still present in Activity Insight' do
+          it 'returns nil' do
+            expect(described_class.find_in_latest_ai_list(pub)).to be_nil
           end
         end
       end

--- a/spec/component/services/publication_cleanup_service_spec.rb
+++ b/spec/component/services/publication_cleanup_service_spec.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+require 'component/component_spec_helper'
+
+describe PublicationCleanupService do
+  describe '.clean_up_pure_publications' do
+    context 'with dependencies mocked' do
+      let(:relation) { instance_double ActiveRecord::Relation }
+      let(:pub) { instance_spy Publication, id: 123 }
+      let(:ppf) { instance_double PurePersonFinder }
+
+      before do
+        allow(relation).to receive(:find_each).and_yield(pub)
+        allow(Publication).to receive(:with_only_pure_imports).and_return relation
+        allow(PurePersonFinder).to receive(:new).and_return ppf
+      end
+
+      context 'when a publication with only Pure imports is not in the current list of Pure publications' do
+        before { allow(SourcePublication).to receive(:find_in_latest_pure_list).with(pub).and_return nil }
+
+        context 'when the publication has an author that is currently in Pure' do
+          before { allow(ppf).to receive(:detect_publication_author).with(pub).and_return(instance_double(User)) }
+
+          context 'when the dry_run option is not set' do
+            it 'outputs a message saying that the publication will be deleted' do
+              expect { described_class.clean_up_pure_publications }.to output("Publication 123 will be deleted\n").to_stdout
+            end
+
+            it 'does not delete the publication' do
+              described_class.clean_up_pure_publications
+              expect(pub).not_to have_received(:destroy!)
+            end
+          end
+
+          context 'when the dry_run option is set to false' do
+            it 'outputs a message saying the the publication is being deleted' do
+              expect { described_class.clean_up_pure_publications(dry_run: false) }.to output("Deleting publication 123\n").to_stdout
+            end
+
+            it 'deletes the publication' do
+              described_class.clean_up_pure_publications(dry_run: false)
+              expect(pub).to have_received(:destroy!)
+            end
+          end
+        end
+
+        context 'when the publication has no authors that are currently in Pure' do
+          before { allow(ppf).to receive(:detect_publication_author).with(pub).and_return(nil) }
+
+          context 'when the dry_run option is not set' do
+            it 'does not delete the publication' do
+              described_class.clean_up_pure_publications
+              expect(pub).not_to have_received(:destroy!)
+            end
+          end
+
+          context 'when the dry_run option is set to false' do
+            it 'does not delete the publication' do
+              described_class.clean_up_pure_publications(dry_run: false)
+              expect(pub).not_to have_received(:destroy!)
+            end
+          end
+        end
+      end
+
+      context 'when a publication with only Pure imports is in the current list of Pure publications' do
+        before { allow(SourcePublication).to receive(:find_in_latest_pure_list).with(pub).and_return pub }
+
+        context 'when the publication has an author that is currently in Pure' do
+          before { allow(ppf).to receive(:detect_publication_author).with(pub).and_return(instance_double(User)) }
+
+          context 'when the dry_run option is not set' do
+            it 'does not delete the publication' do
+              described_class.clean_up_pure_publications
+              expect(pub).not_to have_received(:destroy!)
+            end
+          end
+
+          context 'when the dry_run option is set to false' do
+            it 'does not delete the publication' do
+              described_class.clean_up_pure_publications(dry_run: false)
+              expect(pub).not_to have_received(:destroy!)
+            end
+          end
+        end
+
+        context 'when the publication has no authors that are currently in Pure' do
+          before { allow(ppf).to receive(:detect_publication_author).with(pub).and_return(nil) }
+
+          context 'when the dry_run option is not set' do
+            it 'does not delete the publication' do
+              described_class.clean_up_pure_publications
+              expect(pub).not_to have_received(:destroy!)
+            end
+          end
+
+          context 'when the dry_run option is set to false' do
+            it 'does not delete the publication' do
+              described_class.clean_up_pure_publications(dry_run: false)
+              expect(pub).not_to have_received(:destroy!)
+            end
+          end
+        end
+      end
+    end
+
+    context 'with real internal dependencies' do
+      let!(:pub1) { create(:publication) }
+      let!(:pub1_author) { create(:user, pure_uuid: 'asdfghjkl') }
+
+      let!(:pub2) { create(:publication) }
+      let!(:pub2_author) { create(:user, pure_uuid: 'qwertyui') }
+
+      let!(:pub3) { create(:publication) }
+      let!(:pub3_author) { create(:user, pure_uuid: 'zxcvbnm') }
+
+      let!(:latest_pure_import) {
+        create(
+          :import,
+          source: 'Pure',
+          started_at: 2.hours.ago,
+          completed_at: 1.hour.ago
+        )
+      }
+
+      before do
+        create(:publication_import, publication: pub1, source: 'Pure', source_identifier: 'abc123')
+        create(:authorship, user: pub1_author, publication: pub1)
+        create(:source_publication, source_identifier: 'abc123', import: latest_pure_import)
+
+        create(:publication_import, publication: pub2, source: 'Pure', source_identifier: 'def456')
+        create(:authorship, user: pub2_author, publication: pub2)
+
+        create(:publication_import, publication: pub3, source: 'Pure', source_identifier: 'jkl789')
+        create(:authorship, user: pub3_author, publication: pub3)
+
+        allow(HTTParty).to receive(:get).with(
+          'https://pure.psu.edu/ws/api/524/persons/qwertyui',
+          headers: { 'api-key' => Settings.pure.api_key }
+        ).and_return(instance_double(HTTParty::Response, code: 200))
+
+        allow(HTTParty).to receive(:get).with(
+          'https://pure.psu.edu/ws/api/524/persons/zxcvbnm',
+          headers: { 'api-key' => Settings.pure.api_key }
+        ).and_return(instance_double(HTTParty::Response, code: 404))
+      end
+
+      it 'deletes the correct publications' do
+        expect {
+          described_class.clean_up_pure_publications(dry_run: false)
+        }.to change(Publication, :count).by(-1)
+
+        expect { pub2.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+end

--- a/spec/component/services/pure_person_finder_spec.rb
+++ b/spec/component/services/pure_person_finder_spec.rb
@@ -9,17 +9,17 @@ describe PurePersonFinder do
     let(:user1) { instance_double(User, pure_uuid: 'abc123') }
     let(:user2) { instance_double(User, pure_uuid: 'def456') }
 
-      before do
-        allow(HTTParty).to receive(:get).with(
-          'https://pure.psu.edu/ws/api/524/persons/abc123',
-          headers: { 'api-key' => Settings.pure.api_key }
-        ).and_return response1
+    before do
+      allow(HTTParty).to receive(:get).with(
+        'https://pure.psu.edu/ws/api/524/persons/abc123',
+        headers: { 'api-key' => Settings.pure.api_key }
+      ).and_return response1
 
-        allow(HTTParty).to receive(:get).with(
-          'https://pure.psu.edu/ws/api/524/persons/def456',
-          headers: { 'api-key' => Settings.pure.api_key }
-        ).and_return response2
-      end
+      allow(HTTParty).to receive(:get).with(
+        'https://pure.psu.edu/ws/api/524/persons/def456',
+        headers: { 'api-key' => Settings.pure.api_key }
+      ).and_return response2
+    end
 
     context 'when the given publication does not have an author that is present in the Pure dataset' do
       let(:response1) { instance_double HTTParty::Response, code: 404 }

--- a/spec/component/services/pure_person_finder_spec.rb
+++ b/spec/component/services/pure_person_finder_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'component/component_spec_helper'
+
+describe PurePersonFinder do
+  describe '#detect_publication_author' do
+    let(:finder) { described_class.new }
+    let(:pub) { instance_double(Publication, users: [user1, user2]) }
+    let(:user1) { instance_double(User, pure_uuid: 'abc123') }
+    let(:user2) { instance_double(User, pure_uuid: 'def456') }
+
+      before do
+        allow(HTTParty).to receive(:get).with(
+          'https://pure.psu.edu/ws/api/524/persons/abc123',
+          headers: { 'api-key' => Settings.pure.api_key }
+        ).and_return response1
+
+        allow(HTTParty).to receive(:get).with(
+          'https://pure.psu.edu/ws/api/524/persons/def456',
+          headers: { 'api-key' => Settings.pure.api_key }
+        ).and_return response2
+      end
+
+    context 'when the given publication does not have an author that is present in the Pure dataset' do
+      let(:response1) { instance_double HTTParty::Response, code: 404 }
+      let(:response2) { instance_double HTTParty::Response, code: 404 }
+
+      it 'returns nil' do
+        expect(finder.detect_publication_author(pub)).to be_nil
+      end
+    end
+
+    context 'when the given publication has an author that is present in the Pure dataset' do
+      let(:response1) { instance_double HTTParty::Response, code: 404 }
+      let(:response2) { instance_double HTTParty::Response, code: 200 }
+
+      it 'returns the present author' do
+        expect(finder.detect_publication_author(pub)).to eq user2
+      end
+    end
+  end
+end

--- a/spec/factories/import.rb
+++ b/spec/factories/import.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :import do
+    source { 'Pure' }
+    started_at { Time.current }
+  end
+end

--- a/spec/factories/source_publication.rb
+++ b/spec/factories/source_publication.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :source_publication do
+    import { create(:import) }
+    source_identifier { 'asdf' }
+  end
+end


### PR DESCRIPTION
closes #944

This feature can be used from the Rails console or Rails runner by calling `PublicationCleanupService.call`. By default, it won't do anything except print the list of publications that it would delete to stdout. To actually delete the publications, call it with the option, `PublicationCleanupService.call(dry_run: false)`.

This process takes a while (at least several hours) to complete, and it makes some external HTTP calls. There is currently no error handling for network errors, etc., but if the actual deletion process is interrupted by an error, then it can just be started again, and it will pick up where it left off.

For the process to run at all, both a Pure import and an Activity Insight import will need to have been completed since the release of #1090. Otherwise, the process will simply raise an error.