### PR TITLE
Allow some more actions for admins

### DIFF
--- a/app/models/admin/users.rb
+++ b/app/models/admin/users.rb
@@ -163,6 +163,7 @@ module Admin::Users
             !bindings[:view]._current_user.is_admin
           end
         end
+        field(:ai_title) { label 'Title' }
         field(:pure_uuid) do
           label 'Pure ID'
           read_only do

--- a/app/rails_admin_actions/delete.rb
+++ b/app/rails_admin_actions/delete.rb
@@ -38,6 +38,8 @@ module RailsAdmin
                 flash[:success] = t('admin.flash.successful', name: @model_config.label, action: t('admin.actions.delete.done'))
                 if @object.is_a? OpenAccessLocation
                   redirect_to show_path(model_name: :publication, id: @object.publication.id)
+                elsif @object.is_a? EducationHistoryItem
+                  redirect_to show_path(model_name: :user, id: @object.user.id)
                 else
                   redirect_to index_path
                 end

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -107,7 +107,8 @@ RailsAdmin.config do |config|
             :OpenAccessLocation,
             :Publication,
             :User,
-            :Authorship]
+            :Authorship,
+            :EducationHistoryItem]
     end
     index_publications_by_organization do
       only [:Publication]

--- a/spec/integration/admin/education_history_items/delete_spec.rb
+++ b/spec/integration/admin/education_history_items/delete_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'integration/integration_spec_helper'
+require 'integration/admin/shared_examples_for_admin_page'
+
+describe 'deleting an education history item via the admin interface', type: :feature do
+  let!(:ehi) { create(:education_history_item,
+                      user: user) }
+  let(:user) { create(:user) }
+
+  context 'when the current user is an admin' do
+    before do
+      authenticate_admin_user
+      visit rails_admin.delete_path(model_name: :education_history_item, id: ehi.id)
+    end
+
+    describe 'visiting the form to delete the education history item' do
+      it_behaves_like 'a page with the admin layout'
+
+      it 'show the correct content' do
+        expect(page).to have_content 'Are you sure you want to delete this education history item'
+      end
+    end
+
+    describe 'submitting the form to delete the education history item' do
+      before { click_button "Yes, I'm sure" }
+
+      it 'destroys the education history item' do
+        expect { ehi.reload }.to raise_error ActiveRecord::RecordNotFound
+      end
+
+      it "redirects to the detail page for the deleted item's user" do
+        expect(page).to have_current_path rails_admin.show_path(model_name: :user, id: user.id), ignore_query: true
+      end
+    end
+  end
+
+  context 'when the current user is not an admin' do
+    before { authenticate_user }
+
+    it 'redirects back to the home page with an error message' do
+      visit rails_admin.delete_path(model_name: :education_history_item, id: ehi.id)
+      expect(page).to have_current_path root_path, ignore_query: true
+      expect(page).to have_content I18n.t('admin.authorization.not_authorized')
+    end
+  end
+end

--- a/spec/integration/admin/users/update_spec.rb
+++ b/spec/integration/admin/users/update_spec.rb
@@ -57,6 +57,7 @@ describe 'updating a user via the admin interface', type: :feature do
         fill_in 'First name', with: 'Robert'
         fill_in 'Middle name', with: 'Allen'
         fill_in 'Last name', with: 'Testerson'
+        fill_in 'Title', with: 'Staff'
         fill_in 'Pure ID', with: 'pure-def456'
         fill_in 'Activity Insight ID', with: 'ai-ghi111'
         fill_in 'Penn State ID', with: '123456789'
@@ -76,6 +77,10 @@ describe 'updating a user via the admin interface', type: :feature do
 
       it "updates the user record's last name" do
         expect(user.reload.last_name).to eq 'Testerson'
+      end
+
+      it "updates the user record's title" do
+        expect(user.reload.ai_title).to eq 'Staff'
       end
 
       it "updates the user record's Pure UUID" do


### PR DESCRIPTION
Allow admins to edit a user's 'ai_title' and allow admins to delete education history items.