### PR TITLE
1050 - changes the asset url to vary depending on env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,4 @@ SETTINGS__azure_ad_oauth__oauth_token_url=
 SETTINGS__pure__api_key=
 SETTINGS__scholarsphere__client_key=
 SETTINGS__scholarsphere__endpoint=
+SETTINGS__external_assets__endpoint=

--- a/app/views/layouts/public.html.erb
+++ b/app/views/layouts/public.html.erb
@@ -8,17 +8,17 @@
     <%= csp_meta_tag %>
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= stylesheet_link_tag    'bundle', media: 'all', 'data-turbolinks-track': 'reload' %>
-    <link rel="preload" href="https://assets.libraries.psu.edu/psulib_base/assets/fonts/Roboto/roboto-regular-webfont.woff2" as="font" type="font/woff2" crossorigin="crossorigin">
-    <link rel="preload" href="https://assets.libraries.psu.edu/psulib_base/assets/fonts/Roboto/roboto-bold-webfont.woff2" as="font" type="font/woff2" crossorigin="crossorigin">
-    <link rel="preload" href="https://assets.libraries.psu.edu/psulib_base/assets/fonts/Roboto/roboto-italic-webfont.woff2" as="font" type="font/woff2" crossorigin="crossorigin">
-    <link rel="preload" href="https://assets.libraries.psu.edu/psulib_base/assets/fonts/Roboto_Slab/static/RobotoSlab-Bold.woff2" as="font" type="font/woff2" crossorigin="crossorigin">
-    <link rel="preload" href="https://assets.libraries.psu.edu/psulib_base/assets/fonts/Roboto_Condensed/RobotoCondensed-VariableFont_wght.woff2" as="font" type="font/woff2" crossorigin="crossorigin">
-    <link rel="stylesheet" href="https://assets.libraries.psu.edu/psulib_base/assets/fonts/fonts.css">
-    <link rel="stylesheet" href="https://assets.libraries.psu.edu/psulib_base/dist/peripheral/peripheral.min.css">
-    <link rel="stylesheet" href="https://assets.libraries.psu.edu/psulib_base/dist/peripheral/components/header_mark/header_mark.css">
-    <link rel="stylesheet" href="https://assets.libraries.psu.edu/psulib_base/dist/peripheral/components/header/header.css">
-    <link rel="stylesheet" href="https://assets.libraries.psu.edu/psulib_base/dist/peripheral/components/footer/footer.css">
-    <link rel="stylesheet" href="https://assets.libraries.psu.edu/psulib_base/dist/peripheral/components/sidebar_menu/sidebar_menu.css">
+    <link rel="preload" href="<%= Settings.external_assets.endpoint %>/psulib_base/assets/fonts/Roboto/roboto-regular-webfont.woff2" as="font" type="font/woff2" crossorigin="crossorigin">
+    <link rel="preload" href="<%= Settings.external_assets.endpoint %>/psulib_base/assets/fonts/Roboto/roboto-bold-webfont.woff2" as="font" type="font/woff2" crossorigin="crossorigin">
+    <link rel="preload" href="<%= Settings.external_assets.endpoint %>/psulib_base/assets/fonts/Roboto/roboto-italic-webfont.woff2" as="font" type="font/woff2" crossorigin="crossorigin">
+    <link rel="preload" href="<%= Settings.external_assets.endpoint %>/psulib_base/assets/fonts/Roboto_Slab/static/RobotoSlab-Bold.woff2" as="font" type="font/woff2" crossorigin="crossorigin">
+    <link rel="preload" href="<%= Settings.external_assets.endpoint %>/psulib_base/assets/fonts/Roboto_Condensed/RobotoCondensed-VariableFont_wght.woff2" as="font" type="font/woff2" crossorigin="crossorigin">
+    <link rel="stylesheet" href="<%= Settings.external_assets.endpoint %>/psulib_base/assets/fonts/fonts.css">
+    <link rel="stylesheet" href="<%= Settings.external_assets.endpoint %>/psulib_base/dist/peripheral/peripheral.min.css">
+    <link rel="stylesheet" href="<%= Settings.external_assets.endpoint %>/psulib_base/dist/peripheral/components/header_mark/header_mark.css">
+    <link rel="stylesheet" href="<%= Settings.external_assets.endpoint %>/psulib_base/dist/peripheral/components/header/header.css">
+    <link rel="stylesheet" href="<%= Settings.external_assets.endpoint %>/psulib_base/dist/peripheral/components/footer/footer.css">
+    <link rel="stylesheet" href="<%= Settings.external_assets.endpoint %>/psulib_base/dist/peripheral/components/sidebar_menu/sidebar_menu.css">
     <%= stylesheet_link_tag    'public', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
     <%= javascript_include_tag "bundle", "data-turbo-track": "reload", defer: true %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -46,4 +46,6 @@ scholarsphere:
   client_key: 
   webhook_secret: 
 
+external_assets:
+  endpoint:
 


### PR DESCRIPTION
There is a QA environment for the assets (including fonts) that we want our qa rmd site to point to. Making the external assets variable should address this.