### PR TITLE
Fix /delayed_job - host not permitted error

### DIFF
--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -3,6 +3,14 @@
 Delayed::Worker.max_attempts = 1
 Delayed::Worker.destroy_failed_jobs = false
 
+# Sinatra 4.x / rack-protection 4.x adds a strict HostAuthorization middleware that
+# by default only allows localhost. We must explicitly permit the app's host per
+# environment. Rails' ActionDispatch::HostAuthorization already protects the app at
+# the outer Rack layer; this just satisfies the inner Sinatra check.
+permitted = [Settings.default_url_options.host]
+permitted << 'www.example.com' if Rails.env.test? # Rails request spec default host
+DelayedJobWeb.set :host_authorization, { permitted_hosts: permitted }
+
 if Rails.env.test?
   Delayed::Worker.delay_jobs = false
 end

--- a/spec/component/models/orcid_integration_spec.rb
+++ b/spec/component/models/orcid_integration_spec.rb
@@ -42,8 +42,11 @@ describe OrcidAPIClient do
     let(:employments_hash) { JSON.parse(get_employments) }
     let(:json_resource) { JSON.parse(resource.to_json) }
     let(:employment_path) do
-      employments_hash['affiliation-group'].max_by { |l| l['summaries'].last['employment-summary']['path'] }['summaries'].last['employment-summary']['path']
+      employments_hash['affiliation-group']
+        .max_by { |l| l['summaries'].last['employment-summary']['put-code'].to_i }['summaries']
+        .last['employment-summary']['path']
     end
+
     let(:employment_summary) { employments_hash['affiliation-group'].last['summaries'].last['employment-summary'] }
 
     after do

--- a/spec/requests/delayed_job_spec.rb
+++ b/spec/requests/delayed_job_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'requests/requests_spec_helper'
+
+describe 'GET /delayed_job' do # rubocop:disable RSpec/DescribeClass
+  context 'when not logged in' do
+    it 'returns 404 (route is hidden from unauthenticated users)' do
+      get '/delayed_job'
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  context 'when logged in as a non-admin user' do
+    let(:user) { create(:user, is_admin: false) }
+
+    before do
+      sign_in_as(user)
+      get '/users/auth/azure_oauth/callback'
+    end
+
+    it 'returns 404 (route is hidden from non-admins)' do
+      get '/delayed_job'
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  context 'when logged in as an admin user' do
+    let(:user) { create(:user, is_admin: true) }
+
+    before do
+      sign_in_as(user)
+      get '/users/auth/azure_oauth/callback'
+    end
+
+    it 'returns 200' do
+      get '/delayed_job'
+      follow_redirect! # Sinatra redirects /delayed_job → /delayed_job/ (trailing slash)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end

--- a/spec/requests/requests_spec_helper.rb
+++ b/spec/requests/requests_spec_helper.rb
@@ -2,6 +2,7 @@
 
 require 'rails_helper'
 require 'support/database_cleaner'
+require 'support/authentication'
 require 'support/factory_bot'
 require 'support/request_helpers'
 require 'support/fixture'


### PR DESCRIPTION
Fix /delayed_job "Host not permitted" error in production and QA

Summary
delayed_job_web uses Sinatra 4.x which introduced Rack::Protection::HostAuthorization as a hard-coded middleware that only allows localhost by default
Configured DelayedJobWeb with the app's permitted host per environment via :host_authorization setting in the initializer
Added request specs covering unauthenticated, non-admin, and admin access to the route
Closes #1159 
