### PR TITLE
1199 doi verification job

### DIFF
--- a/app/importers/unpaywall_client.rb
+++ b/app/importers/unpaywall_client.rb
@@ -8,7 +8,8 @@ class UnpaywallClient
       json = JSON.parse(HttpService.get(find_url))
     else
       find_url = "https://api.unpaywall.org/v2/search/?query=#{CGI.escape(publication.title)}&email=openaccess@psu.edu"
-      json = JSON.parse(HttpService.get(find_url))['results'].blank? ? '' : JSON.parse(HttpService.get(find_url))['results'].first['response']
+      result = JSON.parse(HttpService.get(find_url))
+      json = result['results'].blank? ? '' : result['results'].first['response']
     end
 
     UnpaywallResponse.new(json)

--- a/app/jobs/doi_verification_job.rb
+++ b/app/jobs/doi_verification_job.rb
@@ -7,15 +7,29 @@ class DOIVerificationJob < ApplicationJob
     publication = Publication.find(publication_id)
     return if publication.doi_verified == true
 
+    unpaywall_response = nil
+
     if publication.doi.present?
       DOIVerificationService.new(publication).verify
     else
-      response = UnpaywallClient.query_unpaywall(publication)
-      if publication.matchable_title == response.matchable_title && response.doi.present?
-        publication.update!(doi: response.doi, doi_verified: true)
+      unpaywall_response = UnpaywallClient.query_unpaywall(publication)
+      if publication.matchable_title == unpaywall_response.matchable_title && unpaywall_response.doi.present?
+        publication.update!(doi: unpaywall_response.doi, doi_verified: true)
       else
         publication.update!(doi_verified: false)
       end
     end
+
+    sleep 1 unless Rails.env.test?
+  rescue StandardError => e
+    ImporterErrorLog.log_error(
+      importer_class: self.class,
+      error: e,
+      metadata: {
+        publication_id: publication&.id,
+        publication_doi_url_path: publication&.doi_url_path,
+        unpaywall_response: unpaywall_response.to_s
+      }
+    )
   end
 end

--- a/spec/component/jobs/doi_verification_job_spec.rb
+++ b/spec/component/jobs/doi_verification_job_spec.rb
@@ -89,6 +89,28 @@ describe DOIVerificationJob, type: :job do
       end
     end
 
+    context 'when an error is raised during unpaywall lookup' do
+      let(:pub_doi) { nil }
+
+      before do
+        allow(UnpaywallClient).to receive(:query_unpaywall).and_raise(RuntimeError)
+        allow(ImporterErrorLog).to receive(:log_error)
+      end
+
+      it 'logs the error to ImporterErrorLog' do
+        job.perform_now(publication.id)
+        expect(ImporterErrorLog).to have_received(:log_error).with(
+          importer_class: described_class,
+          error: an_instance_of(RuntimeError),
+          metadata: hash_including(publication_id: publication.id)
+        )
+      end
+
+      it 'does not re-raise the error' do
+        expect { job.perform_now(publication.id) }.not_to raise_error
+      end
+    end
+
     context 'when the publication has already been verified' do
       let(:doi_verified) { true }
       let(:pub_title) { 'Psychotherapy integration' }

--- a/spec/component/jobs/file_permissions_check_job_spec.rb
+++ b/spec/component/jobs/file_permissions_check_job_spec.rb
@@ -30,7 +30,7 @@ describe FilePermissionsCheckJob, type: :job do
     context 'when some permissions data is returned' do
       context 'when all fields are present' do
         before do
-          allow(HTTParty).to receive(:get).with('https://bg.api.oa.works/permissions/10.1016%2FS0962-1849%2805%2980014-9')
+          allow(HttpService).to receive(:get).with('https://bg.api.oa.works/permissions/10.1016%2FS0962-1849%2805%2980014-9')
             .and_return(Rails.root.join('spec', 'fixtures', 'oaw7.json').read)
         end
 
@@ -72,7 +72,7 @@ describe FilePermissionsCheckJob, type: :job do
         let(:version) { 'acceptedVersion' }
 
         before do
-          allow(HTTParty).to receive(:get).with('https://bg.api.oa.works/permissions/10.1016%2FS0962-1849%2805%2980014-9')
+          allow(HttpService).to receive(:get).with('https://bg.api.oa.works/permissions/10.1016%2FS0962-1849%2805%2980014-9')
             .and_return(Rails.root.join('spec', 'fixtures', 'oaw10.json').read)
         end
 
@@ -93,7 +93,7 @@ describe FilePermissionsCheckJob, type: :job do
       let(:version) { 'acceptedVersion' }
 
       before do
-        allow(HTTParty).to receive(:get).with('https://bg.api.oa.works/permissions/10.1016%2FS0962-1849%2805%2980014-9')
+        allow(HttpService).to receive(:get).with('https://bg.api.oa.works/permissions/10.1016%2FS0962-1849%2805%2980014-9')
           .and_return(Rails.root.join('spec', 'fixtures', 'oaw5.json').read)
       end
 

--- a/spec/component/jobs/publication_permissions_check_job_spec.rb
+++ b/spec/component/jobs/publication_permissions_check_job_spec.rb
@@ -17,7 +17,7 @@ describe PublicationPermissionsCheckJob, type: :job do
                                 doi: 'https://doi.org/10.1016/S0962-1849(05)80014-9')}
 
     before do
-      allow(HTTParty).to receive(:get).with('https://bg.api.oa.works/permissions/10.1016%2FS0962-1849%2805%2980014-9')
+      allow(HttpService).to receive(:get).with('https://bg.api.oa.works/permissions/10.1016%2FS0962-1849%2805%2980014-9')
         .and_return(Rails.root.join('spec', 'fixtures', 'oaw6.json').read)
     end
 

--- a/spec/component/services/oaw_permissions_service_spec.rb
+++ b/spec/component/services/oaw_permissions_service_spec.rb
@@ -222,7 +222,7 @@ describe OAWPermissionsService do
     describe '#permissions_found?' do
       context 'when some permissions are found' do
         before do
-          allow(HTTParty).to receive(:get).and_return(Rails.root.join('spec', 'fixtures', 'oaw7.json').read)
+          allow(HttpService).to receive(:get).and_return(Rails.root.join('spec', 'fixtures', 'oaw7.json').read)
         end
 
         it 'returns true' do
@@ -232,7 +232,7 @@ describe OAWPermissionsService do
 
       context 'when no permissions data is returned' do
         before do
-          allow(HTTParty).to receive(:get).and_return(Rails.root.join('spec', 'fixtures', 'oaw5.json').read)
+          allow(HttpService).to receive(:get).and_return(Rails.root.join('spec', 'fixtures', 'oaw5.json').read)
         end
 
         it 'returns false' do

--- a/spec/component/services/oaw_preferred_permissions_service_spec.rb
+++ b/spec/component/services/oaw_preferred_permissions_service_spec.rb
@@ -6,17 +6,17 @@ describe OAWPreferredPermissionsService do
   let(:service) { described_class.new(doi) }
 
   before do
-    allow(HTTParty).to receive(:get).with('https://bg.api.oa.works/permissions/10.1016%2FS0962-1849%2805%2980014-9')
+    allow(HttpService).to receive(:get).with('https://bg.api.oa.works/permissions/10.1016%2FS0962-1849%2805%2980014-9')
       .and_return(Rails.root.join('spec', 'fixtures', 'oaw6.json').read)
-    allow(HTTParty).to receive(:get).with('https://bg.api.oa.works/permissions/10.1038%2Fs41598-023-28289-6')
+    allow(HttpService).to receive(:get).with('https://bg.api.oa.works/permissions/10.1038%2Fs41598-023-28289-6')
       .and_return(Rails.root.join('spec', 'fixtures', 'oaw7.json').read)
-    allow(HTTParty).to receive(:get).with('https://bg.api.oa.works/permissions/10.1175%2FJCLI-D-14-00749.1')
+    allow(HttpService).to receive(:get).with('https://bg.api.oa.works/permissions/10.1175%2FJCLI-D-14-00749.1')
       .and_return(Rails.root.join('spec', 'fixtures', 'oaw8.json').read)
-    allow(HTTParty).to receive(:get).with('https://bg.api.oa.works/permissions/10.1146%2Fannurev-earth-040610-133408')
+    allow(HttpService).to receive(:get).with('https://bg.api.oa.works/permissions/10.1146%2Fannurev-earth-040610-133408')
       .and_return(Rails.root.join('spec', 'fixtures', 'oaw9.json').read)
-    allow(HTTParty).to receive(:get).with('https://bg.api.oa.works/permissions/10.1542%2Fpir.25-11-381')
+    allow(HttpService).to receive(:get).with('https://bg.api.oa.works/permissions/10.1542%2Fpir.25-11-381')
       .and_return(Rails.root.join('spec', 'fixtures', 'oaw10.json').read)
-    allow(HTTParty).to receive(:get).with('https://bg.api.oa.works/permissions/some_unknown_doi')
+    allow(HttpService).to receive(:get).with('https://bg.api.oa.works/permissions/some_unknown_doi')
       .and_return(%{{"all_permissions": []}})
   end
 


### PR DESCRIPTION
DOIVerificationJob had no error handling, so uncaught JSON::ParserError
exceptions from Unpaywall's non-JSON rate-limit (429) response bodies
bubbled out of the job and generated BugSnag alerts.

- Rescue StandardError in DOIVerificationJob#perform and log via
  ImporterErrorLog, matching the pattern in UnpaywallPublicationImporter
- Add `sleep 1 unless Rails.env.test?` throttle to ease API pressure
- Fix duplicate HttpService.get call in UnpaywallClient#query_unpaywall
  (search path was hitting Unpaywall twice per lookup)
- Stub HttpService (not HTTParty) in OAW permissions specs to test at
  the correct abstraction layer

Closes #1199