### PR TITLE
Update CircleCI configuration and add GitHub workflow for branch dele…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ parameters:
     default: ""
   CI_UTILS_IMAGE_TAG:
     type: string
-    default: "v4.3.0"
+    default: "v4.6.4"
   CONFIG_REPO_NAME:
     type: string
     default: "researcher-metadata-config"
@@ -34,6 +34,9 @@ parameters:
   CLUSTERS_PROD:
     type: string
     default: "prod"
+  CLUSTERS_ULPROD:
+    type: string
+    default: "ulprod"
   REGISTRY_HOST:
     type: string
     default: "harbor.k8s.libraries.psu.edu"
@@ -92,9 +95,9 @@ jobs:
       registry_host: << pipeline.parameters.REGISTRY_HOST >>
     environment:
       clusters: << parameters.clusters >>
-      CONFIG_REPO: git@github.com:psu-libraries/researcher-metadata-config.git
       CONFIG_REPO_NAME: << pipeline.parameters.CONFIG_REPO_NAME >>
-      REGISTRY_HOST: harbor.k8s.libraries.psu.edu
+      CONFIG_REPO: << pipeline.parameters.CONFIG_REPO_URL >>
+      REGISTRY_HOST: << pipeline.parameters.REGISTRY_HOST >>
       FROM_TAG: << parameters.from_tag >>
       TO_TAG: << parameters.to_tag >>
       PIPELINE_CONFIG_VERSION: << pipeline.parameters.PIPELINE_CONFIG_VERSION >>
@@ -103,19 +106,7 @@ jobs:
       - run:
           name: Tag & Release Image
           command: |
-            export TRIGGERED_BY="$CIRCLE_USERNAME"
-            export REGISTRY_REPO="$CIRCLE_PROJECT_REPONAME"
-            /usr/local/bin/image-tag
-            cd $CONFIG_REPO_NAME
-
-            # Split comma-separated clusters into array and loop
-            clusters="${clusters// /}"
-            IFS=',' read -ra CLUSTERS \<<< "$clusters"
-            for cluster in "${CLUSTERS[@]}"; do
-              export TARGET_CLUSTER="$cluster"
-              echo "Processing cluster: $TARGET_CLUSTER"
-              /usr/local/bin/image-release-pr "clusters/$TARGET_CLUSTER/manifests/$CIRCLE_PROJECT_REPONAME/prod.yaml"
-            done
+            /usr/local/bin/image-release-for-clusters
 
 
   deploy-application:
@@ -127,6 +118,7 @@ jobs:
       clusters: << parameters.clusters >>
       CONFIG_REPO_NAME: << pipeline.parameters.CONFIG_REPO_NAME >>
       CONFIG_REPO_URL: << pipeline.parameters.CONFIG_REPO_URL >>
+      CONFIG_REPO: << pipeline.parameters.CONFIG_REPO_URL >>
     parameters:
       clusters:
         type: string
@@ -278,9 +270,23 @@ jobs:
 
 # We use workflows to orchestrate the jobs that we declared above.
 workflows:
-  version: 2
-  rmd-ci-cd:     # The name of our workflow is "build_and_test"
-    jobs:             # The list of jobs we run as part of this workflow.
+
+  delete-deployment:
+    when:
+      equal: [ "delete", << pipeline.parameters.GHA_Event >> ]
+    jobs:
+      - delete-deployment:
+          name: delete-deployment
+          context: [org-global]
+          delete_branch: << pipeline.parameters.GHA_Meta >>
+          filters:
+            branches:
+              only: /.*/
+
+  rmd-ci-cd:
+    unless:
+      equal: [ "delete", << pipeline.parameters.GHA_Event >> ]
+    jobs:
       - push-image:
           name: push-image
           context:
@@ -328,7 +334,7 @@ workflows:
           context:
             - org-global
           name: "Release"
-          clusters: << pipeline.parameters.CLUSTERS_PROD >>
+          clusters: << pipeline.parameters.CLUSTERS_PROD >>,<< pipeline.parameters.CLUSTERS_ULPROD >>
           from_tag: "<< pipeline.git.revision >>"
           to_tag: "<< pipeline.git.tag >>"
           filters:

--- a/.github/workflows/delete-branch-deployment.yml
+++ b/.github/workflows/delete-branch-deployment.yml
@@ -1,0 +1,14 @@
+name: Branch Deleted
+on:
+  delete
+jobs:
+  delete-deployment:
+    if: contains(github.event.ref, 'update/') || contains(github.event.ref, 'preview/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger CircleCI Pipeline
+        uses: CircleCI-Public/trigger-circleci-pipeline-action@v1.2.0
+        with:
+          GHA_Meta: "${{ github.event.ref }}"
+        env:
+          CCI_TOKEN: ${{ secrets.CCI_TOKEN }}


### PR DESCRIPTION
This pull request updates the CI/CD pipeline to improve environment handling, add support for a new deployment cluster, and automate cleanup when branches are deleted. The most significant changes include updating the CI utility image, introducing a new deployment cluster, streamlining image release logic, and integrating branch deletion handling between GitHub Actions and CircleCI.

**CI/CD Pipeline Improvements:**

* Updated the `CI_UTILS_IMAGE_TAG` parameter in `.circleci/config.yml` to use version `v4.6.4` for newer CI utilities.
* Streamlined the image release process by replacing the manual cluster loop and release commands with a single `/usr/local/bin/image-release-for-clusters` command in the `Tag & Release Image` step.

**Deployment Environment Enhancements:**

* Added a new `CLUSTERS_ULPROD` parameter to support deployments to the `ulprod` cluster, and updated the release workflow to deploy to both `prod` and `ulprod` clusters. [[1]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47R37-R39) [[2]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L331-R337)

**Configuration Handling:**

* Changed configuration parameters to use pipeline values for `CONFIG_REPO` and `REGISTRY_HOST`, making the configuration more flexible and less hardcoded. [[1]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L95-R100) [[2]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47R121)

**Branch Deletion Automation:**

* Added a new GitHub Actions workflow `.github/workflows/delete-branch-deployment.yml` to trigger a CircleCI job that deletes deployments when branches with `update/` or `preview/` in their names are deleted.
* Updated CircleCI workflows to include a `delete-deployment` job that runs only when a branch is deleted, and skips the main workflow in that case.…tion