### PR TITLE
Fixed metadata field name

### DIFF
--- a/app/models/scholarsphere_work_deposit.rb
+++ b/app/models/scholarsphere_work_deposit.rb
@@ -95,7 +95,7 @@ class ScholarsphereWorkDeposit < ApplicationRecord
     base_metadata[:publisher_statement] = publisher_statement if publisher_statement.present?
     if standard_oa_workflow? && doi.present?
       base_metadata[:open_access] = true
-      base_metadata[:metadata_imported_from_rmd] = true
+      base_metadata[:imported_metadata_from_rmd] = true
     end
     base_metadata
   end

--- a/spec/component/models/scholarsphere_work_deposit_spec.rb
+++ b/spec/component/models/scholarsphere_work_deposit_spec.rb
@@ -495,7 +495,7 @@ describe ScholarsphereFileUpload, type: :model do
             { display_name: 'Another Contributor' }
           ],
           open_access: true,
-          metadata_imported_from_rmd: true
+          imported_metadata_from_rmd: true
         })
       end
     end


### PR DESCRIPTION
I got the attribute name backwards.  Its `imported_metadata_from_rmd` not `metadata_imported_from_rmd`.