### PR TITLE
Alert user when ScholarSphere upload fails

### DIFF
--- a/app/components/export_metadata_link_component.html.erb
+++ b/app/components/export_metadata_link_component.html.erb
@@ -1,6 +1,14 @@
-  <%= form_with url: scholarsphere_deposit_path(@publication.id), method: :post do |f| %>
-    <button type="submit"
-            class="btn btn-primary">
-      Deposit to Scholarsphere
-    </button>
+  <% if scholarsphere_export_failed? %>
+    <div class="alert alert-warning" role="alert">
+      <%= helpers.fa_icon('exclamation-triangle') %>&nbsp;
+      <%= t('components.export_metadata_link_component.failed_message_html',
+            email_link: helpers.mail_to('openaccess@psu.edu', 'openaccess@psu.edu')) %>
+    </div>
+  <% else %>
+    <%= form_with url: scholarsphere_deposit_path(@publication.id), method: :post do |f| %>
+      <button type="submit"
+              class="btn btn-primary">
+        <%= t('components.export_metadata_link_component.deposit_button') %>
+      </button>
+    <% end %>
   <% end %>

--- a/app/components/export_metadata_link_component.html.erb
+++ b/app/components/export_metadata_link_component.html.erb
@@ -1,8 +1,7 @@
   <% if scholarsphere_export_failed? %>
     <div class="alert alert-warning" role="alert">
-      <%= helpers.fa_icon('exclamation-triangle') %>&nbsp;
-      <%= t('components.export_metadata_link_component.failed_message_html',
-            email_link: helpers.mail_to('openaccess@psu.edu', 'openaccess@psu.edu')) %>
+      <%= failed_alert_icon %>&nbsp;
+      <%= failed_message_html %>
     </div>
   <% else %>
     <%= form_with url: scholarsphere_deposit_path(@publication.id), method: :post do |f| %>

--- a/app/components/export_metadata_link_component.rb
+++ b/app/components/export_metadata_link_component.rb
@@ -6,4 +6,8 @@ class ExportMetadataLinkComponent < ViewComponent::Base
   def initialize(publication:)
     @publication = publication
   end
+
+  def scholarsphere_export_failed?
+    publication.scholarsphere_upload_failed?
+  end
 end

--- a/app/components/export_metadata_link_component.rb
+++ b/app/components/export_metadata_link_component.rb
@@ -10,4 +10,13 @@ class ExportMetadataLinkComponent < ViewComponent::Base
   def scholarsphere_export_failed?
     publication.scholarsphere_upload_failed?
   end
+
+  def failed_alert_icon
+    helpers.fa_icon('exclamation-triangle')
+  end
+
+  def failed_message_html
+    I18n.t('components.export_metadata_link_component.failed_message_html',
+           email_link: helpers.mail_to('openaccess@psu.edu', 'openaccess@psu.edu')).html_safe
+  end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -112,6 +112,10 @@ en:
     destroy:
       success: Successfully removed the proxy assignment.
       error: Something went wrong when deleting this proxy. Please contact support to resolve the issue.
+  components:
+    export_metadata_link_component:
+      failed_message_html: "Upload to ScholarSphere failed. Please contact the Office of Scholarly Communications and Copyright at %{email_link}."
+      deposit_button: "Deposit to ScholarSphere"
   layouts:
     manage_profile:
       nav:

--- a/spec/component/components/export_metadata_link_component_spec.rb
+++ b/spec/component/components/export_metadata_link_component_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'component/component_spec_helper'
+
+RSpec.describe ExportMetadataLinkComponent, type: :component do
+  let(:publication) { create(:publication) }
+
+  context 'when a ScholarSphere export failed' do
+    let(:authorship) { create(:authorship, publication: publication) }
+
+    before do
+      create(:scholarsphere_work_deposit, authorship: authorship, status: 'Failed')
+      render_inline(described_class.new(publication: publication))
+    end
+
+    it 'shows a warning alert with contact information' do
+      expect(rendered_content).to have_css('.alert.alert-warning')
+      expect(rendered_content).to have_text(I18n.t('components.export_metadata_link_component.failed_message_html',
+                                                   email_link: 'openaccess@psu.edu'))
+      expect(rendered_content).to have_link('openaccess@psu.edu', href: 'mailto:openaccess@psu.edu')
+    end
+
+    it 'does not show the deposit button' do
+      expect(rendered_content).to have_no_button(I18n.t('components.export_metadata_link_component.deposit_button'))
+    end
+  end
+
+  context 'when a ScholarSphere export has not failed' do
+    before do
+      render_inline(described_class.new(publication: publication))
+    end
+
+    it 'shows the deposit button' do
+      expect(rendered_content).to have_button(I18n.t('components.export_metadata_link_component.deposit_button'))
+    end
+
+    it 'does not show a warning alert' do
+      expect(rendered_content).to have_no_css('.alert.alert-warning')
+    end
+  end
+end

--- a/spec/integration/profiles/open_access_publications/edit_spec.rb
+++ b/spec/integration/profiles/open_access_publications/edit_spec.rb
@@ -131,14 +131,14 @@ describe 'visiting the page to edit the open access status of a publication', ty
 
         it 'creates a new ScholarsphereWorkDeposit' do
           initial_count = ScholarsphereWorkDeposit.count
-          click_on 'Deposit to Scholarsphere'
+          click_on 'Deposit to ScholarSphere'
           after_count = ScholarsphereWorkDeposit.count
           expect(after_count - initial_count).to eq(1)
           expect(ScholarsphereWorkDeposit.last.draft_scholarsphere_work_deposit_url).to eq("#{scholarsphere_base_uri}/the-url")
         end
 
         it 'reroutes to Scholarsphere' do
-          click_on 'Deposit to Scholarsphere'
+          click_on 'Deposit to ScholarSphere'
           sleep 0.1
           expect(page.current_url).to eq("#{scholarsphere_base_uri}#{edit_url_path}")
         end
@@ -148,12 +148,12 @@ describe 'visiting the page to edit the open access status of a publication', ty
           let(:response_body) { %{{"error" : "some error"}} }
 
           it 'displays an error message when something goes wrong' do
-            click_on 'Deposit to Scholarsphere'
+            click_on 'Deposit to ScholarSphere'
             expect(page).to have_content I18n.t('profile.open_access_publications.create_scholarsphere_deposit.fail')
           end
 
           it 'saves the failure to the ScholarsphereWorkDeposit' do
-            click_on 'Deposit to Scholarsphere'
+            click_on 'Deposit to ScholarSphere'
             expect(ScholarsphereWorkDeposit.last.status).to eq('Failed')
             expect(ScholarsphereWorkDeposit.last.error_message).to eq('{"error" : "some error"}')
           end


### PR DESCRIPTION
Adds logic to hide "Deposit to ScholarSphere" button when upload has already failed.  Show an alert message instead.  Adds tests for the view component and refactors text into translation file.

closes #1248 

<img width="1154" height="322" alt="Screenshot 2026-06-05 at 3 18 20 PM" src="https://github.com/user-attachments/assets/9579657d-90a9-47bd-b7c9-362c24de5ff9" />
