### PR TITLE
Pass `deputy` to ScholarSphere deposit

### DIFF
--- a/app/controllers/open_access_publications_controller.rb
+++ b/app/controllers/open_access_publications_controller.rb
@@ -49,7 +49,7 @@ class OpenAccessPublicationsController < OpenAccessWorkflowController
       @deposit.save!
       @authorship.update!(updated_by_owner_at: Time.current)
     end
-    service = ScholarsphereDepositService.new(@deposit, current_user)
+    service = ScholarsphereDepositService.new(@deposit, current_user.deputy.presence || current_user)
     edit_url = service.create_draft
     redirect_to edit_url, allow_other_host: true
   rescue ActiveRecord::RecordInvalid => e

--- a/spec/component/controllers/open_access_publications_controller_spec.rb
+++ b/spec/component/controllers/open_access_publications_controller_spec.rb
@@ -469,6 +469,12 @@ describe OpenAccessPublicationsController, type: :controller do
             expect(service).to have_received(:create_draft)
           end
 
+          it 'passes the current user to ScholarsphereDepositService when not masquerading' do
+            post :create_scholarsphere_deposit, params: params
+            expect(ScholarsphereDepositService).to have_received(:new)
+              .with(instance_of(ScholarsphereWorkDeposit), user)
+          end
+
           it 'redirects to the url returned by the deposit service' do
             post :create_scholarsphere_deposit, params: params
             expect(response).to redirect_to(test_url)
@@ -504,6 +510,11 @@ describe OpenAccessPublicationsController, type: :controller do
 
           it 'adds the deputy user id to the work deposit' do
             expect(found_deposit.deputy_user_id).to eq(deputy.id)
+          end
+
+          it 'passes the deputy user to ScholarsphereDepositService as depositor' do
+            expect(ScholarsphereDepositService).to have_received(:new)
+              .with(instance_of(ScholarsphereWorkDeposit), deputy)
           end
         end
       end


### PR DESCRIPTION
When a proxy is uploading in RMD, the depositor was only being set to the `current_user` (the person being proxied for).  This breaks the integration because the depositor is the person who can edit the upload in ScholarSphere, so the proxy can't get to the edit pages.  This is fixed by checking for the proxy (`deputy`) and sending that as the depositor if it exists.  Otherwise, the `current_user` is used.

Note that if `current_user` does not have a `deputy`, `current_user.deputy` returns a `NullUser` object that behaves like `nil`.