### PR TITLE
Fix flaky file version review spec

### DIFF
--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -232,6 +232,7 @@ class Publication < ApplicationRecord
       .where(%{EXISTS (SELECT * FROM activity_insight_oa_files WHERE activity_insight_oa_files.publication_id = publications.id AND activity_insight_oa_files.version = 'unknown')})
       .where(%{NOT EXISTS (SELECT * FROM activity_insight_oa_files WHERE activity_insight_oa_files.publication_id = publications.id AND publications.preferred_version = activity_insight_oa_files.version)})
       .where(%{NOT EXISTS (SELECT * FROM activity_insight_oa_files WHERE activity_insight_oa_files.publication_id = publications.id AND activity_insight_oa_files.version IS NULL)})
+      .order(:id)
   }
   scope :wrong_file_version_base, -> {
     nonflagged_activity_insight_oa_publication

--- a/spec/integration/admin/activity_insight_oa_workflow/file_version_review_spec.rb
+++ b/spec/integration/admin/activity_insight_oa_workflow/file_version_review_spec.rb
@@ -46,15 +46,9 @@ describe 'Admin File Version Review dashboard', type: :feature do
 
   describe 'clicking a link to edit a file' do
     it "redirects to that Activity Insight OA File's edit page" do
-      # click_link('Edit metadata in admin dashboard', match: :first)
-      # TODO: The code below may be less flaky than the line above
-      # If it is keep the less flaky code and remove the line above
-      # and replace it anywhere else in the test suite.
-      second_tr = find_all('tr')[1]
-      within second_tr do
-        click_link 'Edit metadata in admin dashboard'
-      end
-      expect(page).to have_current_path rails_admin.edit_path(model_name: :activity_insight_oa_file, id: aif1.id)
+      edit_path = rails_admin.edit_path(model_name: :activity_insight_oa_file, id: aif1.id)
+      click_link 'Edit metadata in admin dashboard', href: edit_path
+      expect(page).to have_current_path edit_path
     end
   end
 end


### PR DESCRIPTION
## Summary
- Add `.order(:id)` to `Publication.file_version_check_failed` so the admin File Version Review page lists publications in a stable order.
- Make `file_version_review_spec.rb` click the edit link by its unique href instead of picking a table row by position (`find_all('tr')[1]`), resolving the old TODO about flakiness in that spec.

## Why
CI failed on `file_version_review_spec.rb:48` on an unrelated branch: the scope has no `ORDER BY`, so Postgres returns publications in arbitrary heap order, and the test assumed the first table row belonged to `pub1`. Any branch that shifts the test database's row layout can trip this flake.

The scope's other two usages are unaffected by the ordering: a `.count` on the OA dashboard (Rails strips `ORDER BY` from count queries) and an order-independent `contain_exactly` assertion in `publication_spec.rb`.

## Testing
- `spec/integration/admin/activity_insight_oa_workflow/file_version_review_spec.rb` — 3 examples, 0 failures
- `spec/component/models/publication_spec.rb` — 456 examples, 0 failures
- `spec/component/components/activity_insight_oa_dashboard_component_spec.rb` — 19 examples, 0 failures
- RuboCop: no offenses