### PR TITLE
Rename open_access to open_access_upload in scholarsphere metadata export

### DIFF
--- a/app/models/scholarsphere_work_deposit.rb
+++ b/app/models/scholarsphere_work_deposit.rb
@@ -94,7 +94,7 @@ class ScholarsphereWorkDeposit < ApplicationRecord
     base_metadata[:publisher] = [publisher] if publisher.present?
     base_metadata[:publisher_statement] = publisher_statement if publisher_statement.present?
     if standard_oa_workflow? && doi.present?
-      base_metadata[:open_access] = true
+      base_metadata[:open_access_upload] = true
       base_metadata[:imported_metadata_from_rmd] = true
     end
     base_metadata

--- a/spec/component/models/scholarsphere_work_deposit_spec.rb
+++ b/spec/component/models/scholarsphere_work_deposit_spec.rb
@@ -494,7 +494,7 @@ describe ScholarsphereFileUpload, type: :model do
             { display_name: 'Test Author' },
             { display_name: 'Another Contributor' }
           ],
-          open_access: true,
+          open_access_upload: true,
           imported_metadata_from_rmd: true
         })
       end


### PR DESCRIPTION
Depends on: psu-libraries/scholarsphere#1996

Renames `open_access` to `open_access_upload` in `ScholarsphereWorkDeposit#metadata` to match the renamed column in ScholarSphere.