### PR TITLE
Adds 'scholarsphere_edit_url' to ScholarsphereWorkDeposit

### DIFF
--- a/app/decorators/authorship_decorator.rb
+++ b/app/decorators/authorship_decorator.rb
@@ -68,11 +68,16 @@ class AuthorshipDecorator < BaseDecorator
     end
 
     def profile_management_pub_title
-      if no_open_access_information? && is_oa_publication? && published? && confirmed
+      if should_link_to_open_access_page?
         view_context.link_to title, view_context.edit_open_access_publication_path(publication)
       else
         title
       end
+    end
+
+    def should_link_to_open_access_page?
+      (no_open_access_information? || scholarsphere_upload_pending?) &&
+        is_oa_publication? && published? && confirmed
     end
 
     def wrap_title(title)

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -657,6 +657,14 @@ class Publication < ApplicationRecord
     authorships.where(%{id IN (SELECT authorship_id FROM scholarsphere_work_deposits WHERE status = 'Pending')}).any?
   end
 
+  def scholarsphere_pending_edit_url
+    ScholarsphereWorkDeposit
+      .where(authorship_id: authorships.select(:id), status: 'Pending')
+      .where.not(scholarsphere_edit_url: [nil, ''])
+      .order(created_at: :desc)
+      .pick(:scholarsphere_edit_url)
+  end
+
   def scholarsphere_upload_failed?
     authorships.where(%{id IN (SELECT authorship_id FROM scholarsphere_work_deposits WHERE status = 'Failed')}).any?
   end

--- a/app/models/scholarsphere_work_deposit.rb
+++ b/app/models/scholarsphere_work_deposit.rb
@@ -144,6 +144,7 @@ class ScholarsphereWorkDeposit < ApplicationRecord
         field(:title)
         field(:deposit_workflow)
         field(:draft_scholarsphere_work_deposit_url)
+        field(:scholarsphere_edit_url)
       end
     end
 end

--- a/app/services/scholarsphere_deposit_service.rb
+++ b/app/services/scholarsphere_deposit_service.rb
@@ -25,8 +25,12 @@ class ScholarsphereDepositService
     # Draft works will return a 201
     if response.status == 201 || !response_body['edit_url'].nil?
       base_url = ResearcherMetadata::Application.scholarsphere_base_uri
-      deposit.update(draft_scholarsphere_work_deposit_url: response_body['url'].to_s)
-      "#{base_url}#{response_body['edit_url']}?external_entry=true"
+      edit_url = "#{base_url}#{response_body['edit_url']}?external_entry=true"
+      deposit.update(
+        draft_scholarsphere_work_deposit_url: response_body['url'].to_s,
+        scholarsphere_edit_url: edit_url
+      )
+      edit_url
     else
       logger.info response.inspect
       raise DepositFailed.new(response.body)

--- a/app/views/open_access_publications/readonly_edit.html.erb
+++ b/app/views/open_access_publications/readonly_edit.html.erb
@@ -44,7 +44,7 @@
             <% if publication.preferred_open_access_url %>
               <td>This publication is open access - <%= link_to publication.preferred_open_access_url, publication.preferred_open_access_url, target: '_blank' %></td>
             <% elsif publication.scholarsphere_upload_pending? %>
-              <td>This publication is in the process of being added to <%= link_to "Scholarsphere", "https://scholarsphere.psu.edu/", target: '_blank' %>.</td>
+              <td>This publication is in the process of being added to <%= link_to "Scholarsphere", publication.scholarsphere_pending_edit_url || "https://scholarsphere.psu.edu/", target: '_blank' %>.</td>
             <% elsif publication.open_access_waived? %>
               <td>Open access obligations have been waived for this publication.</td>
             <% end %>

--- a/db/migrate/20260618120000_add_scholarsphere_edit_url_to_scholarsphere_work_deposits.rb
+++ b/db/migrate/20260618120000_add_scholarsphere_edit_url_to_scholarsphere_work_deposits.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddScholarsphereEditURLToScholarsphereWorkDeposits < ActiveRecord::Migration[7.2]
+  def change
+    add_column :scholarsphere_work_deposits, :scholarsphere_edit_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_05_29_142542) do
+ActiveRecord::Schema[7.2].define(version: 2026_06_18_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
@@ -573,6 +573,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_29_142542) do
     t.string "deposit_workflow"
     t.integer "activity_insight_oa_file_id"
     t.string "draft_scholarsphere_work_deposit_url"
+    t.string "scholarsphere_edit_url"
     t.index ["authorship_id"], name: "index_scholarsphere_work_deposits_on_authorship_id"
     t.index ["deputy_user_id"], name: "index_scholarsphere_work_deposits_on_deputy_user_id"
   end

--- a/spec/component/models/publication_spec.rb
+++ b/spec/component/models/publication_spec.rb
@@ -2014,6 +2014,56 @@ describe Publication, type: :model do
     end
   end
 
+  describe '#scholarsphere_pending_edit_url' do
+    let(:pub) { create(:publication) }
+    let(:auth) { create(:authorship, publication: pub) }
+
+    context 'when there is a pending deposit with an edit url' do
+      before do
+        create(:scholarsphere_work_deposit,
+               authorship: auth,
+               status: 'Pending',
+               scholarsphere_edit_url: 'https://scholarsphere.test/works/1/edit?external_entry=true')
+      end
+
+      it 'returns the pending deposit edit url' do
+        expect(pub.scholarsphere_pending_edit_url).to eq 'https://scholarsphere.test/works/1/edit?external_entry=true'
+      end
+    end
+
+    context 'when there are multiple pending deposits with edit urls' do
+      before do
+        create(:scholarsphere_work_deposit,
+               authorship: auth,
+               status: 'Pending',
+               scholarsphere_edit_url: 'https://scholarsphere.test/works/old/edit?external_entry=true',
+               created_at: 2.days.ago)
+        create(:scholarsphere_work_deposit,
+               authorship: auth,
+               status: 'Pending',
+               scholarsphere_edit_url: 'https://scholarsphere.test/works/new/edit?external_entry=true',
+               created_at: 1.day.ago)
+      end
+
+      it 'returns the most recent pending deposit edit url' do
+        expect(pub.scholarsphere_pending_edit_url).to eq 'https://scholarsphere.test/works/new/edit?external_entry=true'
+      end
+    end
+
+    context 'when pending deposits exist but none have an edit url' do
+      before do
+        create(:scholarsphere_work_deposit,
+               authorship: auth,
+               status: 'Pending',
+               scholarsphere_edit_url: nil)
+      end
+
+      it 'returns nil' do
+        expect(pub.scholarsphere_pending_edit_url).to be_nil
+      end
+    end
+  end
+
   describe '#scholarsphere_upload_failed?' do
     let(:pub) { create(:publication) }
     let(:auth) { create(:authorship, publication: pub) }

--- a/spec/component/models/scholarsphere_work_deposit_spec.rb
+++ b/spec/component/models/scholarsphere_work_deposit_spec.rb
@@ -27,6 +27,7 @@ describe 'the scholarsphere_work_deposits table', type: :model do
   it { is_expected.to have_db_column(:deposit_workflow).of_type(:string) }
   it { is_expected.to have_db_column(:activity_insight_oa_file_id).of_type(:integer) }
   it { is_expected.to have_db_column(:draft_scholarsphere_work_deposit_url).of_type(:string) }
+  it { is_expected.to have_db_column(:scholarsphere_edit_url).of_type(:string) }
 
   it { is_expected.to have_db_index(:authorship_id) }
   it { is_expected.to have_db_index :deputy_user_id }

--- a/spec/component/services/scholarsphere_deposit_service_spec.rb
+++ b/spec/component/services/scholarsphere_deposit_service_spec.rb
@@ -46,7 +46,12 @@ describe ScholarsphereDepositService do
 
     it "saves the url to the deposit's draft_scholarship_work_deposit_url" do
       service.create_draft
-      expect(deposit).to have_received(:update).with({ draft_scholarsphere_work_deposit_url: '/the-url' })
+      expect(deposit).to have_received(:update).with(
+        {
+          draft_scholarsphere_work_deposit_url: '/the-url',
+          scholarsphere_edit_url: 'https://scholarsphere.test/the-edit-url?external_entry=true'
+        }
+      )
     end
 
     it 'returns the edit_url from the body' do

--- a/spec/integration/profiles/edit_spec.rb
+++ b/spec/integration/profiles/edit_spec.rb
@@ -313,7 +313,7 @@ describe 'editing profile preferences' do
           expect(page).to have_content "Bob's Non-Open Access Publication"
           expect(page).to have_no_link "Bob's Non-Open Access Publication"
           expect(page).to have_content "Bob's Pending Scholarsphere Publication"
-          expect(page).to have_no_link "Bob's Pending Scholarsphere Publication"
+          expect(page).to have_link "Bob's Pending Scholarsphere Publication", href: edit_open_access_publication_path(pub_6)
           expect(page).to have_content "Bob's In Press Publication"
           expect(page).to have_no_link "Bob's In Press Publication"
           expect(page).to have_content "Bob's Uploaded to Activity Insight"

--- a/spec/integration/profiles/open_access_publications/edit_spec.rb
+++ b/spec/integration/profiles/open_access_publications/edit_spec.rb
@@ -57,7 +57,12 @@ describe 'visiting the page to edit the open access status of a publication', ty
 
   let!(:waived_auth) { create(:authorship, user: user, publication: waived_pub) }
   let!(:ss_deposited_auth) { create(:authorship, user: user, publication: ss_pub) }
-  let!(:swd) { create(:scholarsphere_work_deposit, authorship: ss_deposited_auth, status: 'Pending') }
+  let!(:swd) {
+    create(:scholarsphere_work_deposit,
+           authorship: ss_deposited_auth,
+           status: 'Pending',
+           scholarsphere_edit_url: 'https://scholarsphere.test/works/999/edit?external_entry=true')
+  }
 
   before do
     create(:authorship, user: user, publication: oa_pub)
@@ -234,6 +239,7 @@ describe 'visiting the page to edit the open access status of a publication', ty
 
       it 'shows the open access status of the publication' do
         expect(page).to have_content 'This publication is in the process of being added to Scholarsphere'
+        expect(page).to have_link 'Scholarsphere', href: 'https://scholarsphere.test/works/999/edit?external_entry=true'
       end
     end
 

--- a/spec/unit/decorators/authorship_decorator_spec.rb
+++ b/spec/unit/decorators/authorship_decorator_spec.rb
@@ -247,6 +247,16 @@ describe AuthorshipDecorator do
       end
     end
 
+    context 'when a Scholarsphere upload is pending' do
+      let(:title) { 'Test Title' }
+      let(:no_info) { false }
+      let(:pending) { true }
+
+      it 'returns a label with a link to the publication open access page' do
+        expect(ad.profile_management_label).to eq %{<span class="publication-title">the pub link</span>}
+      end
+    end
+
     context 'when the given object is not a journal article' do
       context 'when the given object has a title' do
         let(:title) { 'Test Title' }


### PR DESCRIPTION
This stores the url to start the upload process in Scholarsphere.  This is used when the upload is still 'In Progress' to take the user back to Scholarsphere in case they don't complete the upload process.