### PR TITLE
Rescue and store errors when PubMed fetch fails

### DIFF
--- a/app/importers/nih_api_client.rb
+++ b/app/importers/nih_api_client.rb
@@ -31,8 +31,17 @@ class NIHAPIClient
       limit: REQUEST_RECORD_LIMIT
     )['results']
 
-    nih_pubs.map do |p|
+    nih_pubs.filter_map do |p|
       HTTParty.get("https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?db=pubmed&id=#{p['pmid']}").body
+    rescue StandardError => e
+      log_error(
+        e,
+        {
+          project_number: project_number,
+          pmid: p['pmid']
+        }
+      )
+      nil
     end
   end
 
@@ -63,6 +72,14 @@ class NIHAPIClient
         criteria: { org_names: ['The Pennsylvania State University'] },
         offset: offset,
         limit: limit
+      )
+    end
+
+    def log_error(error, metadata)
+      ImporterErrorLog.log_error(
+        importer_class: self.class,
+        error: error,
+        metadata: metadata
       )
     end
 end

--- a/spec/component/models/nih_api_client_spec.rb
+++ b/spec/component/models/nih_api_client_spec.rb
@@ -106,12 +106,12 @@ describe NIHAPIClient do # rubocop:disable RSpec/SpecFilePathFormat
         allow(HTTParty).to receive(:get).with(
           'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?db=pubmed&id=pm123'
         ).and_raise(error)
-        allow(ImporterErrorLog).to receive(:log_error)
       end
 
       it 'logs the error and skips the failed PubMed record' do
-        expect(client.publications_by_project('abc123')).to eq ['publication 2']
+        allow(ImporterErrorLog).to receive(:log_error)
 
+        expect(client.publications_by_project('abc123')).to eq ['publication 2']
         expect(ImporterErrorLog).to have_received(:log_error).with(
           importer_class: described_class,
           error: error,
@@ -119,6 +119,26 @@ describe NIHAPIClient do # rubocop:disable RSpec/SpecFilePathFormat
             project_number: 'abc123',
             pmid: 'pm123'
           }
+        )
+      end
+
+      it 'creates an ImporterErrorLog record' do
+        # Mock JSON.parse to override top level mocks
+        allow(JSON).to receive(:parse).with(
+          { project_number: 'abc123', pmid: 'pm123' }.to_json,
+          { quirks_mode: true }
+        ).and_return({ 'project_number' => 'abc123', 'pmid' => 'pm123' })
+        expect { client.publications_by_project('abc123') }.to change(ImporterErrorLog, :count).by(1)
+        # Allow JSON.parse to operate normally for downstream calls
+        allow(JSON).to receive(:parse).and_call_original
+
+        error_log = ImporterErrorLog.order(:created_at).last
+        expect(error_log.importer_type).to eq('NIHAPIClient')
+        expect(error_log.error_type).to eq('StandardError')
+        expect(error_log.error_message).to eq('pubmed timeout')
+        expect(error_log.metadata).to eq(
+          'project_number' => 'abc123',
+          'pmid' => 'pm123'
         )
       end
     end

--- a/spec/component/models/nih_api_client_spec.rb
+++ b/spec/component/models/nih_api_client_spec.rb
@@ -98,5 +98,29 @@ describe NIHAPIClient do # rubocop:disable RSpec/SpecFilePathFormat
     it 'returns the publication metadata from PubMed for the given NIH project number' do
       expect(client.publications_by_project('abc123')).to eq ['publication 1', 'publication 2']
     end
+
+    context 'when fetching a PubMed record raises an error' do
+      let(:error) { StandardError.new('pubmed timeout') }
+
+      before do
+        allow(HTTParty).to receive(:get).with(
+          'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?db=pubmed&id=pm123'
+        ).and_raise(error)
+        allow(ImporterErrorLog).to receive(:log_error)
+      end
+
+      it 'logs the error and skips the failed PubMed record' do
+        expect(client.publications_by_project('abc123')).to eq ['publication 2']
+
+        expect(ImporterErrorLog).to have_received(:log_error).with(
+          importer_class: described_class,
+          error: error,
+          metadata: {
+            project_number: 'abc123',
+            pmid: 'pm123'
+          }
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
When running the NIH import in ULDEV, it repeatedly fails after about 1.5 hours with a TCP connection error.  I'm not too sure the cause, but since it's a connection error, and right now appears to maybe just be one record, I think it makes sense to rescue it, log it, and continue the import.