### PR TITLE
Bump erb from 5.0.1 to 6.0.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -199,7 +199,7 @@ GEM
     docile (1.4.1)
     drb (2.2.3)
     ed25519 (1.3.0)
-    erb (5.0.1)
+    erb (6.0.4)
     erb_lint (0.9.0)
       activesupport
       better_html (>= 2.0.1)


### PR DESCRIPTION
Major version bump of erb from 5.0.1 to 6.0.4 to resolve a high-severity Dependabot alert (`@_init` deserialization guard bypass). erb is a transitive dependency.