### PR TITLE
Bump view_component from 3.21.0 to 4.12.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,11 +158,11 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     colorize (1.1.0)
-    concurrent-ruby (1.3.5)
+    concurrent-ruby (1.3.7)
     config (5.5.2)
       deep_merge (~> 1.2, >= 1.2.1)
       ostruct
-    connection_pool (2.5.4)
+    connection_pool (3.0.2)
     crack (1.0.0)
       bigdecimal
       rexml
@@ -240,7 +240,7 @@ GEM
       csv
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
-    i18n (1.14.7)
+    i18n (1.15.2)
       concurrent-ruby (~> 1.0)
     image_processing (1.14.0)
       mini_magick (>= 4.9.5, < 6)
@@ -311,7 +311,9 @@ GEM
       logger
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
-    minitest (5.26.0)
+    minitest (6.0.6)
+      drb (~> 2.0)
+      prism (~> 1.5)
     multi_json (1.15.0)
     multi_xml (0.8.1)
       bigdecimal (>= 3.1, < 5)
@@ -641,10 +643,10 @@ GEM
     vcr (6.3.1)
       base64
     version_gem (1.1.8)
-    view_component (3.21.0)
-      activesupport (>= 5.2.0, < 8.1)
-      concurrent-ruby (~> 1.0)
-      method_source (~> 1.0)
+    view_component (4.12.0)
+      actionview (>= 7.1.0)
+      activesupport (>= 7.1.0)
+      concurrent-ruby (~> 1)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.2.1)


### PR DESCRIPTION
Major version bump of view_component from 3.21.0 to 4.12.0 to resolve two moderate-severity Dependabot alerts (preview route helper dispatch and system-test path check). Audited the 4 components for the 4.x breaking APIs (slots, `with_collection_parameter`, content areas, VC previews) and found none in use.

Resolving to newest-compatible also re-resolved a few transitives, including minitest 5 -> 6 and connection_pool 2 -> 3. Full RSpec suite matches baseline exactly (5591 examples, 80 failures all pre-existing env-only: 76 webdrivers HOME-permission, 4 `:no_ci` PSU-network specs). Browser/feature specs deferred to CI.
