### PR TITLE
Bump devise from 4.9.4 to 5.0.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'cssbundling-rails'                 # For bundling stylesheets
 gem 'daemons'                           # for running delayed_job daemon (or other processes)
 gem 'delayed_job_active_record'         # for running async jobs
 gem 'delayed_job_web'                   # /delayed_job UI for delayed job
-gem 'devise', '~> 4.9'                  # for authentication and user management
+gem 'devise', '~> 5.0'                  # for authentication and user management
 gem 'exiftool_vendored', '~> 12.33'     # ExifTool for parsing PDF metadata
 gem 'factory_bot_rails'                 # For generating records in test, development, and staging/beta envs
 gem 'ffaker'                            # For generating fake data in test, development, and staging/beta envs

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -189,10 +189,10 @@ GEM
       delayed_job (> 2.0.3)
       rack-protection (>= 1.5.5)
       sinatra (>= 1.4.4)
-    devise (4.9.4)
+    devise (5.0.4)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
-      railties (>= 4.1.0)
+      railties (>= 7.0)
       responders
       warden (~> 1.2.3)
     diff-lcs (1.6.0)
@@ -693,7 +693,7 @@ DEPENDENCIES
   database_cleaner
   delayed_job_active_record
   delayed_job_web
-  devise (~> 4.9)
+  devise (~> 5.0)
   ed25519
   exiftool_vendored (~> 12.33)
   factory_bot_rails


### PR DESCRIPTION
Major version bump of devise 4.9.4 -> 5.0.4 to resolve the devise security advisory. The app only uses devise's `:timeoutable` and `:omniauthable` modules plus standard helpers, and already meets the 5.0 baselines (Rails 7.2, Ruby 3.4, omniauth ~> 2.1 with omniauth-rails_csrf_protection). Audited the initializer config and OmniauthCallbacksController for 5.0-removed APIs and found none in use.