### PR TITLE
Fix Google Scholar Publication Citation Import

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,9 +123,9 @@ for new publications. We import the following types of records from Unpaywall:
     - open_access_locations
 
 1. **Google Scholar** - We scrape Google Scholar via ScraperAPI to enrich faculty citation metrics and
-per-publication citation counts. This import runs on demand. See the
-[Google Scholar Integration](#google-scholar-integration) section for details. We import the following
-types of data:
+per-publication citation counts. This import runs monthly. It is important to conserve ScraperAPI credits 
+used per-request.  These credits reset every month. See the [Google Scholar Integration](#google-scholar-integration) 
+section for details. We import the following types of data:
     - `google_scholar_id`, `google_scholar_h_index`, `google_scholar_citation_total` (user-level)
     - `google_scholar_citation_count` (publication-level)
 
@@ -499,7 +499,7 @@ Once a profile is confirmed, the importer stores `google_scholar_id`, `google_sc
 ### Publication Citation Workflow
 
 A separate `GoogleScholarPublicationCitationImporter` refreshes `publications.google_scholar_citation_count`
-using DOI matching only. Publications without a DOI match are skipped and logged.
+using a DOI search and fuzzy title match. Publications without a DOI match are skipped.
 
 ### Rake Tasks
 

--- a/app/importers/google_scholar_publication_citation_importer.rb
+++ b/app/importers/google_scholar_publication_citation_importer.rb
@@ -30,6 +30,12 @@ class GoogleScholarPublicationCitationImporter
       result = scraper.fetch_publication_by_doi(publication.doi)
       return unless result
 
+      pub_title = publication.title
+      distance = String::Similarity.levenshtein_distance(pub_title, result[:title])
+      max_length = [pub_title.length, result[:title].length].max
+      title_similarity = 1 - (distance / max_length.to_f)
+      return unless title_similarity > 0.85
+
       publication.update!(google_scholar_citation_count: result[:citations])
     rescue StandardError => e
       Rails.logger.warn(

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -534,6 +534,7 @@ class Publication < ApplicationRecord
       field(:authors_et_al) { label 'Et al authors?' }
       field(:published_on)
       field(:total_scopus_citations) { label 'Number of Scopus citations' }
+      field(:google_scholar_citation_count) { label 'Number of Google Scholar citations' }
       field(:created_at) { read_only true }
       field(:updated_at) { read_only true }
       field(:updated_by_user_at) { read_only true }

--- a/lib/utilities/google_scholar_scraper.rb
+++ b/lib/utilities/google_scholar_scraper.rb
@@ -63,7 +63,8 @@ module Utilities
       normalized_doi = normalized_doi(doi)
       return unless normalized_doi
 
-      html = fetch_scholar_search_html(normalized_doi)
+      doi_query = "doi:#{normalized_doi}"
+      html = fetch_scholar_search_html(doi_query)
       return unless html
 
       parse_doi_search_result(html, normalized_doi)

--- a/lib/utilities/google_scholar_scraper.rb
+++ b/lib/utilities/google_scholar_scraper.rb
@@ -76,7 +76,7 @@ module Utilities
       def fetch_scholar_search_html(query)
         scholar_url = "https://scholar.google.com/scholar?q=#{URI.encode_www_form_component(query)}&hl=en"
 
-        fetch_scraperapi_html(scholar_url, "Google Scholar publication search for #{query}")
+        fetch_scraperapi_html(scholar_url, "Google Scholar publication search for #{query}", render: false)
       end
 
       def fetch_page_html(user_id, cstart)
@@ -224,10 +224,9 @@ module Utilities
       def parse_doi_search_result(html, doi)
         doc = Nokogiri::HTML(html)
 
-        doc.css('.gs_r.gs_or.gs_scl').each do |result|
-          result_text = result.text.downcase
-          next unless result_text.include?(doi.downcase)
+        result = doc.css('.gs_r.gs_or.gs_scl').first
 
+        if result.present?
           return {
             doi: doi,
             title: result.at_css('.gs_rt')&.text&.strip,

--- a/spec/component/importers/google_scholar_publication_citation_importer_spec.rb
+++ b/spec/component/importers/google_scholar_publication_citation_importer_spec.rb
@@ -7,16 +7,18 @@ describe GoogleScholarPublicationCitationImporter do
     let(:scraper) { instance_double(Utilities::GoogleScholarScraper) }
     let(:importer) { described_class.new(scraper: scraper) }
 
-    let!(:publication_with_doi) { create(:publication, doi: 'https://doi.org/10.123/example') }
+    let!(:publication_with_doi) do
+      create(:publication, doi: 'https://doi.org/10.123/example', title: 'Machine Learning in Libraries')
+    end
     let!(:publication_without_doi) { create(:publication, doi: nil) }
 
     before do
       allow(scraper).to receive(:fetch_publication_by_doi)
         .with('https://doi.org/10.123/example')
-        .and_return(doi: '10.123/example', citations: 42)
+        .and_return(doi: '10.123/example', title: 'Machine Learning in Librariex', citations: 42)
     end
 
-    it 'updates citation counts for DOI-matched publications only' do
+    it 'updates citation counts for publications with DOIs only' do
       importer.call
 
       expect(publication_with_doi.reload.google_scholar_citation_count).to eq 42
@@ -32,6 +34,34 @@ describe GoogleScholarPublicationCitationImporter do
       end
 
       it 'leaves the publication unchanged' do
+        importer.call
+
+        expect(publication_with_doi.reload.google_scholar_citation_count).to be_nil
+      end
+    end
+
+    context 'when the returned title matches the stored title by more than 85%' do
+      before do
+        allow(scraper).to receive(:fetch_publication_by_doi)
+          .with('https://doi.org/10.123/example')
+          .and_return(doi: '10.123/example', title: 'Machine Learning in Librariex', citations: 7)
+      end
+
+      it 'updates the citation count' do
+        importer.call
+
+        expect(publication_with_doi.reload.google_scholar_citation_count).to eq 7
+      end
+    end
+
+    context 'when the returned title does not match the stored title by more than 85%' do
+      before do
+        allow(scraper).to receive(:fetch_publication_by_doi)
+          .with('https://doi.org/10.123/example')
+          .and_return(doi: '10.123/example', title: 'Completely Different Publication', citations: 99)
+      end
+
+      it 'does not update the citation count' do
         importer.call
 
         expect(publication_with_doi.reload.google_scholar_citation_count).to be_nil


### PR DESCRIPTION
The per-publication citation importer was not importing anything.  There was an issue with the scraper query and no DOI is returned in the Google Scholar output, so we can't match on DOI.  We _do_ search by DOI, but now we use a fuzzy-title match to confirm.