### PR TITLE
Delete ScholarsphereWorkDeposits when withdrawn and use full URLs

### DIFF
--- a/app/controllers/webhooks/scholarsphere_controller.rb
+++ b/app/controllers/webhooks/scholarsphere_controller.rb
@@ -8,9 +8,13 @@ module Webhooks
     def work_withdrawn
       if params[:publication_url].present?
         locations = OpenAccessLocation.where(source: Source::SCHOLARSPHERE, url: params[:publication_url])
-        return head(:not_found) if locations.none?
+        scholarsphere_work_deposits = ScholarsphereWorkDeposit.where(draft_scholarsphere_work_deposit_url: params[:publication_url],
+                                                                     status: ['Success', 'Pending'])
+
+        return head(:not_found) if locations.none? && scholarsphere_work_deposits.none?
 
         locations.destroy_all
+        scholarsphere_work_deposits.destroy_all
         head :no_content
       else
         head :bad_request
@@ -21,10 +25,7 @@ module Webhooks
       return head(:bad_request) if params[:scholarsphere_work_url].blank?
 
       deposit = ScholarsphereWorkDeposit.find_by(draft_scholarsphere_work_deposit_url: params[:scholarsphere_work_url])
-      if deposit
-        full_url = "#{ResearcherMetadata::Application.scholarsphere_base_uri}#{params[:scholarsphere_work_url]}"
-        deposit.record_success(full_url)
-      end
+      deposit&.record_success(params[:scholarsphere_work_url])
       render plain: 'ok'
     end
 

--- a/app/services/scholarsphere_deposit_service.rb
+++ b/app/services/scholarsphere_deposit_service.rb
@@ -25,9 +25,10 @@ class ScholarsphereDepositService
     # Draft works will return a 201
     if response.status == 201 || !response_body['edit_url'].nil?
       base_url = ResearcherMetadata::Application.scholarsphere_base_uri
+      draft_url = "#{base_url}#{response_body['url']}"
       edit_url = "#{base_url}#{response_body['edit_url']}?external_entry=true"
       deposit.update(
-        draft_scholarsphere_work_deposit_url: response_body['url'].to_s,
+        draft_scholarsphere_work_deposit_url: draft_url,
         scholarsphere_edit_url: edit_url
       )
       edit_url

--- a/spec/component/services/scholarsphere_deposit_service_spec.rb
+++ b/spec/component/services/scholarsphere_deposit_service_spec.rb
@@ -30,7 +30,7 @@ describe ScholarsphereDepositService do
   end
 
   describe '#create_draft' do
-    let(:response_body) { %{{"url": "https://scholarsphere.test/the-url", "edit_url":"https://scholarsphere.test/the-edit-url"}} }
+    let(:response_body) { %{{"url": "/the-url", "edit_url":"/the-edit-url"}} }
     let(:status) { 201 }
 
     before do

--- a/spec/component/services/scholarsphere_deposit_service_spec.rb
+++ b/spec/component/services/scholarsphere_deposit_service_spec.rb
@@ -30,7 +30,7 @@ describe ScholarsphereDepositService do
   end
 
   describe '#create_draft' do
-    let(:response_body) { %{{"url": "/the-url", "edit_url":"/the-edit-url"}} }
+    let(:response_body) { %{{"url": "https://scholarsphere.test/the-url", "edit_url":"https://scholarsphere.test/the-edit-url"}} }
     let(:status) { 201 }
 
     before do

--- a/spec/component/services/scholarsphere_deposit_service_spec.rb
+++ b/spec/component/services/scholarsphere_deposit_service_spec.rb
@@ -48,7 +48,7 @@ describe ScholarsphereDepositService do
       service.create_draft
       expect(deposit).to have_received(:update).with(
         {
-          draft_scholarsphere_work_deposit_url: '/the-url',
+          draft_scholarsphere_work_deposit_url: 'https://scholarsphere.test/the-url',
           scholarsphere_edit_url: 'https://scholarsphere.test/the-edit-url?external_entry=true'
         }
       )
@@ -57,6 +57,20 @@ describe ScholarsphereDepositService do
     it 'returns the edit_url from the body' do
       resp = service.create_draft
       expect(resp).to eq('https://scholarsphere.test/the-edit-url?external_entry=true')
+    end
+
+    context 'when the response includes an edit URL but has a status other than 201' do
+      let(:status) { 200 }
+
+      it 'saves the draft URLs and returns the edit URL' do
+        expect(service.create_draft).to eq('https://scholarsphere.test/the-edit-url?external_entry=true')
+        expect(deposit).to have_received(:update).with(
+          {
+            draft_scholarsphere_work_deposit_url: 'https://scholarsphere.test/the-url',
+            scholarsphere_edit_url: 'https://scholarsphere.test/the-edit-url?external_entry=true'
+          }
+        )
+      end
     end
 
     context 'if the scholarsphere client does not return successfully' do

--- a/spec/integration/profiles/open_access_publications/edit_spec.rb
+++ b/spec/integration/profiles/open_access_publications/edit_spec.rb
@@ -139,7 +139,7 @@ describe 'visiting the page to edit the open access status of a publication', ty
           click_on 'Deposit to ScholarSphere'
           after_count = ScholarsphereWorkDeposit.count
           expect(after_count - initial_count).to eq(1)
-          expect(ScholarsphereWorkDeposit.last.draft_scholarsphere_work_deposit_url).to eq('/the-url')
+          expect(ScholarsphereWorkDeposit.last.draft_scholarsphere_work_deposit_url).to eq('https://scholarsphere.test/the-url')
         end
 
         it 'reroutes to Scholarsphere' do

--- a/spec/requests/webhooks/scholarsphere_controller_spec.rb
+++ b/spec/requests/webhooks/scholarsphere_controller_spec.rb
@@ -139,11 +139,52 @@ describe Webhooks::ScholarsphereController do
           expect(response).to have_http_status :no_content
         end
       end
+
+      context 'when given a publication_url param that matches ScholarSphere work deposits' do
+        let!(:pending_deposit) {
+          create(
+            :scholarsphere_work_deposit,
+            draft_scholarsphere_work_deposit_url: 'https://scholarsphere.test/resources/withdrawn-work'
+          )
+        }
+        let!(:successful_deposit) {
+          create(
+            :scholarsphere_work_deposit,
+            status: 'Success',
+            draft_scholarsphere_work_deposit_url: 'https://scholarsphere.test/resources/withdrawn-work'
+          )
+        }
+        let!(:failed_deposit) {
+          create(
+            :scholarsphere_work_deposit,
+            status: 'Failed',
+            draft_scholarsphere_work_deposit_url: 'https://scholarsphere.test/resources/withdrawn-work'
+          )
+        }
+
+        it 'deletes matching pending and successful deposits, but keeps failed deposits' do
+          post(
+            webhooks_scholarsphere_work_withdrawn_path,
+            headers: { 'X-API-KEY' => 'webhooksecret123' },
+            params: { publication_url: 'https://scholarsphere.test/resources/withdrawn-work' }
+          )
+
+          expect(response).to have_http_status :no_content
+          expect { pending_deposit.reload }.to raise_error ActiveRecord::RecordNotFound
+          expect { successful_deposit.reload }.to raise_error ActiveRecord::RecordNotFound
+          expect { failed_deposit.reload }.not_to raise_error
+        end
+      end
     end
   end
 
   describe 'POST /webhooks/scholarsphere/open_access_work_published' do
-    let!(:deposit) { create(:scholarsphere_work_deposit, draft_scholarsphere_work_deposit_url: '/resources/some-uuid') }
+    let!(:deposit) {
+      create(
+        :scholarsphere_work_deposit,
+        draft_scholarsphere_work_deposit_url: 'https://scholarsphere.test/resources/some-uuid'
+      )
+    }
 
     context 'when not given an API key header' do
       it 'returns 401' do
@@ -187,7 +228,7 @@ describe Webhooks::ScholarsphereController do
           post(
             webhooks_scholarsphere_open_access_work_published_path,
             headers: { 'X-API-KEY' => 'webhooksecret123' },
-            params: { scholarsphere_work_url: '/resources/unknown-uuid' }
+            params: { scholarsphere_work_url: 'https://scholarsphere.test/resources/unknown-uuid' }
           )
 
           expect(response).to have_http_status :ok
@@ -200,7 +241,7 @@ describe Webhooks::ScholarsphereController do
           post(
             webhooks_scholarsphere_open_access_work_published_path,
             headers: { 'X-API-KEY' => 'webhooksecret123' },
-            params: { scholarsphere_work_url: '/resources/some-uuid' }
+            params: { scholarsphere_work_url: 'https://scholarsphere.test/resources/some-uuid' }
           )
 
           expect(response).to have_http_status :ok
@@ -211,7 +252,7 @@ describe Webhooks::ScholarsphereController do
           post(
             webhooks_scholarsphere_open_access_work_published_path,
             headers: { 'X-API-KEY' => 'webhooksecret123' },
-            params: { scholarsphere_work_url: '/resources/some-uuid' }
+            params: { scholarsphere_work_url: 'https://scholarsphere.test/resources/some-uuid' }
           )
 
           expect(deposit.reload.status).to eq 'Success'
@@ -221,7 +262,7 @@ describe Webhooks::ScholarsphereController do
           post(
             webhooks_scholarsphere_open_access_work_published_path,
             headers: { 'X-API-KEY' => 'webhooksecret123' },
-            params: { scholarsphere_work_url: '/resources/some-uuid' }
+            params: { scholarsphere_work_url: 'https://scholarsphere.test/resources/some-uuid' }
           )
 
           oal = deposit.publication.open_access_locations.find_by(source: Source::SCHOLARSPHERE)


### PR DESCRIPTION
For more details check out https://github.com/psu-libraries/scholarsphere/pull/2039 .

This PR adds functionality to the "withdrawn" webhook to delete `ScholarsphereWorkDeposits` related to the withdrawn work.  Also, changes to how we store the draft URL on creation so that the full url is stored.  Both the "withdrawn" and "published" webhooks are using full urls now.